### PR TITLE
add -I${includedir}/httpserver to CFLAGS

### DIFF
--- a/libhttpserver.pc.in
+++ b/libhttpserver.pc.in
@@ -10,4 +10,4 @@ Requires: libmicrohttpd >= 0.9.9
 Conflicts:
 Libs: -L${libdir} -lmicrohttpd
 Libs.private: @LHT_LIBDEPS@
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/httpserver


### PR DESCRIPTION
This make swig file generation easier because HTTPSERVER_CFLAGS can be
directly used in swig file generation.
This fix affect only clients that use swing on their code.
