### PR TITLE
made ~http_resource() and ~http_response() virtual to avoid compiler war...

### DIFF
--- a/src/httpserver/http_resource.hpp
+++ b/src/httpserver/http_resource.hpp
@@ -51,7 +51,7 @@ class http_resource
         /**
          * Class destructor
         **/
-        ~http_resource()
+        virtual ~http_resource()
         {
         }
         /**

--- a/src/httpserver/http_response.hpp
+++ b/src/httpserver/http_response.hpp
@@ -209,7 +209,7 @@ class http_response
         {
         }
 
-        ~http_response();
+        virtual ~http_response();
         /**
          * Method used to get the content from the response.
          * @return the content in string form


### PR DESCRIPTION
when compiling with -Wnon-virtual-dtor gcc warned about these two dtors not being virtual. i think it makes sense to declare them virtual
