### PR TITLE
enable building on macos

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -19,7 +19,11 @@
 
 aclocal -I m4
 autoheader
-libtoolize --automake
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    glibtoolize --automake
+else
+    libtoolize --automake
+fi
 automake --add-missing
 autoconf
 

--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -36,6 +36,7 @@
 #include <set>
 #include <string>
 #include <utility>
+#include <stdlib.h>
 #include <memory>
 #include <deque>
 


### PR DESCRIPTION
- enabled MAC OS build by adding an if state to execute glibtoolize instead of libtoolize for building
- included <stblib.h> header that was necessary to made "free" function beeing imported under MacOS
