### PR TITLE
http_response: Change cycle_callback_ptr so that buffer can be modified

### DIFF
--- a/src/http_response.cpp
+++ b/src/http_response.cpp
@@ -207,7 +207,7 @@ namespace details
 
 ssize_t cb(void* cls, uint64_t pos, char* buf, size_t max)
 {
-    ssize_t val = static_cast<http_response*>(cls)->cycle_callback(buf);
+    ssize_t val = static_cast<http_response*>(cls)->cycle_callback(buf, max);
     if(val == -1)
         static_cast<http_response*>(cls)->completed = true;
     return val;

--- a/src/httpserver/http_response.hpp
+++ b/src/httpserver/http_response.hpp
@@ -62,7 +62,7 @@ class bad_caching_attempt: public std::exception
     }
 };
 
-typedef ssize_t(*cycle_callback_ptr)(const std::string&);
+typedef ssize_t(*cycle_callback_ptr)(char*, size_t);
 
 /**
  * Class representing an abstraction for an Http Response. It is used from classes using these apis to send information through http protocol.


### PR DESCRIPTION
With this, the callback can modify the buffer to put the response data there. 'max' should be provided to the callback as well, so that it doesn't write over the end of the buffer.
A char * can't just be passed to the callback as std::string without any conversion.

Also, http_response_builder::deferred_response and cycle_callback_ptr could use some documentation. Some can be adapted from [1] and [2].
[1] https://www.gnu.org/software/libmicrohttpd/manual/libmicrohttpd.html#microhttpd_002dresponse-create
[2] https://www.gnu.org/software/libmicrohttpd/manual/libmicrohttpd.html#microhttpd_002dcb