### PR TITLE
Add CMake module to Makefile.am to be installed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,9 @@ DISTCLEANFILES = redhat/SOURCES/* redhat/SPEC/* redhat/RPMS/* redhat/SRPMS/* red
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libhttpserver.pc
 
+cmakemoduledir = $(datadir)/cmake/Modules
+cmakemodule_DATA = cmakemodule/FindLibHttpServer.cmake
+
 include $(top_srcdir)/aminclude.am
 
 # Update libtool, if needed.


### PR DESCRIPTION
The CMake module wasn't installed by `make install` before.