### PR TITLE
Do not call abort, throw an exception instead

### DIFF
--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -41,6 +41,7 @@
 #include <deque>
 
 #include <pthread.h>
+#include <stdexcept>
 
 #include "httpserver/create_webserver.hpp"
 
@@ -65,6 +66,15 @@ namespace details {
     struct cache_entry;
     class comet_manager;
 }
+
+class webserver_exception : public std::runtime_error
+{
+public:
+	webserver_exception()
+	: std::runtime_error("httpserver runtime error")
+	{
+	}
+};
 
 /**
  * Class representing the webserver. Main class of the apis.

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -280,7 +280,7 @@ void* webserver::select(void* self)
         FD_ZERO (&ws);
         FD_ZERO (&es);
         if (MHD_YES != MHD_get_fdset (di->daemon, &rs, &ws, &es, &max))
-            abort(); /* fatal internal error */
+            throw ::httpserver::webserver_exception(); /* fatal internal error */
 
         unsigned long long timeout_microsecs = 0;
         unsigned long long timeout_secs = 0;
@@ -563,7 +563,7 @@ bool webserver::start(bool blocking)
             {
                 cout << gettext("Unable to connect daemon to port: ") <<
                     this->port << endl;
-                abort();
+                throw ::httpserver::webserver_exception();
             }
             details::daemon_item* di = new details::daemon_item(this, daemon);
             daemons.push_back(di);
@@ -579,7 +579,7 @@ bool webserver::start(bool blocking)
                     static_cast<void*>(di)
             ))
             {
-                abort();
+                throw ::httpserver::webserver_exception();
             }
         }
     }
@@ -595,7 +595,7 @@ bool webserver::start(bool blocking)
         {
             cout << gettext("Unable to connect daemon to port: ") <<
                 this->port << endl;
-            abort();
+            throw ::httpserver::webserver_exception();
         }
         details::daemon_item* di = new details::daemon_item(this, daemon);
         daemons.push_back(di);


### PR DESCRIPTION
Calling abort is a really bad idea inside a library, because the whole application will die when just the HTTP server module has a problem.