### PR TITLE
webserver: stop leaking pthreads on startup failure

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -586,7 +586,7 @@ bool webserver::start(bool blocking)
         } catch (::httpserver::webserver_exception &e) {
             this->running = false;
             for (;i >= 0; --i) {
-                pthread_kill(&threads[i], 9);
+                pthread_kill(threads[i], 9);
             }
             threads.clear();
             throw e;


### PR DESCRIPTION
Since the program no longer aborts when a failure occures, all threads started need to be stopped again.