### PR TITLE
http_resource needs a virtual destructor

### DIFF
--- a/src/httpserver/http_resource.hpp
+++ b/src/httpserver/http_resource.hpp
@@ -204,7 +204,7 @@ class http_resource
         /**
          * Class destructor
         **/
-        ~http_resource()
+        virtual ~http_resource()
         {
         }
 


### PR DESCRIPTION
When creating an *http_resource* derived class with any virtual method (e.g. destructor), the callbacks are called with a broken *this* pointer. (off by sizeof(void*))

This happens because the pointer is modified when downcasting to the base class (to skip the newly introduced *vtable* pointer), but it is not restored to it's original value when upcasting due to the binder/functors using *reinterpret_cast* (it would be corrected to the original pointer value when *static_cast* was used, but that does not work because *generic_class* is not a related class).

This quick fix does not really address the real problem with the functors and the method binding, which will probably also happen when multiple inheritance comes into play, but it circumvents the immediate effects with classes using virtual methods.