### PR TITLE
Bug with large POSTs

### DIFF
--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -442,7 +442,11 @@ class http_request
         **/
         void set_arg(const std::string& key, const std::string& value)
         {
-            this->args[key] = value;
+            if (this->args[key].empty()) {
+                this->args[key] = value;
+            } else {
+                this->args[key].append(value);
+            }
         }
         /**
          * Method used to set an argument value by key.
@@ -452,7 +456,11 @@ class http_request
         **/
         void set_arg(const char* key, const char* value, size_t size)
         {
-            this->args[key] = std::string(value, size);
+            if (this->args[key].empty()) {
+                this->args[key] = std::string(value, size);
+            } else {
+                this->args[key].append(value, size);
+            }
         }
         /**
          * Method used to set the content of the request


### PR DESCRIPTION
For a POST parameter with a large value, libmicrohttpd will call webserver::post_iterator
 multiple times with chunks of post data and successive offsets. Currently, set_arg will
overwrites the value. So after all the post_iterator calls, the value will be
set to the last chunk.

This change fixes the set_arg() function(s).. by checking for an existing value and appending the new chunk.

the bug can be tested with the following script.



STR="1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
1234567890abcdefghijklmnopqrstuvwxyz \
"
curl -X POST --data "aaa=$STR" http://127.0.0.1:8080/service