### PR TITLE
Fix warnings about const results of functions

### DIFF
--- a/src/httpserver/http_response.hpp
+++ b/src/httpserver/http_response.hpp
@@ -110,7 +110,7 @@ class http_response
          * Method used to get the content from the response.
          * @return the content in string form
         **/
-        const std::string get_content()
+        std::string get_content()
         {
             return this->content;
         }
@@ -125,7 +125,7 @@ class http_response
          * @param key The header identification
          * @return a string representing the value assumed by the header
         **/
-        const std::string get_header(const std::string& key)
+        std::string get_header(const std::string& key)
         {
             return this->headers[key];
         }
@@ -140,7 +140,7 @@ class http_response
          * @param key The footer identification
          * @return a string representing the value assumed by the footer
         **/
-        const std::string get_footer(const std::string& key)
+        std::string get_footer(const std::string& key)
         {
             return this->footers[key];
         }
@@ -150,7 +150,7 @@ class http_response
             result = this->footers[key];
         }
 
-        const std::string get_cookie(const std::string& key)
+        std::string get_cookie(const std::string& key)
         {
             return this->cookies[key];
         }
@@ -189,7 +189,7 @@ class http_response
             return this->response_code;
         }
 
-        const std::string get_realm() const
+        std::string get_realm() const
         {
             return this->realm;
         }
@@ -199,7 +199,7 @@ class http_response
             result = this->realm;
         }
 
-        const std::string get_opaque() const
+        std::string get_opaque() const
         {
             return this->opaque;
         }
@@ -209,7 +209,7 @@ class http_response
             result = this->opaque;
         }
 
-        const bool need_nonce_reload() const
+        bool need_nonce_reload() const
         {
             return this->reload_nonce;
         }

--- a/src/httpserver/http_utils.hpp
+++ b/src/httpserver/http_utils.hpp
@@ -303,7 +303,7 @@ struct ip_representation
     ip_representation(const struct sockaddr* ip);
 
     bool operator <(const ip_representation& b) const;
-    const int weight() const
+    int weight() const
     {
         //variable-precision SWAR algorithm
         unsigned int x = mask;

--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -145,22 +145,22 @@ class webserver
         bool is_valid(const std::string& key);
         void clean_cache();
 
-        const log_access_ptr get_access_logger() const
+        log_access_ptr get_access_logger() const
         {
             return this->log_access;
         }
 
-        const log_error_ptr get_error_logger() const
+        log_error_ptr get_error_logger() const
         {
             return this->log_error;
         }
 
-        const validator_ptr get_request_validator() const
+        validator_ptr get_request_validator() const
         {
             return this->validator;
         }
 
-        const unescaper_ptr get_unescaper() const
+        unescaper_ptr get_unescaper() const
         {
             return this->unescaper;
         }


### PR DESCRIPTION
This fixes some warnings I get from gcc 4.9.2 like

/home/boo/ipac/ttmp/libhttpserver-bin/include/httpserver/http_utils.hpp:306:24: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
     const int weight() const
