### PR TITLE
Parse POST's with format of formdata as well as urlencoded.

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -669,7 +669,12 @@ int webserver::bodyfull_requests_answer_first_step(
                                 encoding,
                                 strlen (MHD_HTTP_POST_ENCODING_FORM_URLENCODED)
                                 )
-            ))
+              )
+             || (0 == strncasecmp (
+                                   MHD_HTTP_POST_ENCODING_MULTIPART_FORMDATA,
+                                   encoding,
+                                   strlen (MHD_HTTP_POST_ENCODING_MULTIPART_FORMDATA)
+                                   )))
         )
     )
     {


### PR DESCRIPTION
This enables the underlying capability of libmicrohttpd to parse POST's with the format of "multipart/form-data".  This is useful for parsing simple curl requests like

curl -F "foo=bar" http://localhost/