### PR TITLE
Update debian/ install files to handle the latest multiarch configuration

### DIFF
--- a/debian/libhttpserver-dev.install.in
+++ b/debian/libhttpserver-dev.install.in
@@ -1,4 +1,4 @@
 usr/include
-usr/lib/*.a
-usr/lib/*.so
-usr/lib/pkgconfig
+usr/lib/*/*.a
+usr/lib/*/*.so
+usr/lib/*/pkgconfig

--- a/debian/libhttpserver.install.in
+++ b/debian/libhttpserver.install.in
@@ -1,1 +1,1 @@
-usr/lib/*.so.* 
+usr/lib/*/*.so.* 


### PR DESCRIPTION
With multiarch, debian puts library and pkgconfig files into `/usr/lib/x86_64-linux-gnu/` (for amd64), not `/usr/lib/`.