### PR TITLE
fixed a problem that causes a memory leak. We are passing user, pass,

### DIFF
--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -328,7 +328,7 @@ class webserver
 
         void end_request_construction(MHD_Connection* connection,
                 struct details::modded_request* mr, const char* version,
-                const char* method, char* user, char* pass, char* digested_user
+                const char* method, char* &user, char* &pass, char* &digested_user
         );
 
         int finalize_answer(MHD_Connection* connection,

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -964,9 +964,9 @@ void webserver::end_request_construction(
         struct details::modded_request* mr,
         const char* version,
         const char* method,
-        char* user,
-        char* pass,
-        char* digested_user
+        char* &user,
+        char* &pass,
+        char* &digested_user
 )
 {
     mr->ws = this;


### PR DESCRIPTION
We are passing user, pass and digested_user as char pointers by value which causes the original
pointers be always null when they are going to be free in
complete_request, now we pass them by reference and everything works
fine