### PR TITLE
Manage ipv6 in get_ip_str function

### DIFF
--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -255,10 +255,6 @@ void get_ip_str(
         {
             result = to_ret;
         }
-        else
-        {
-            result.clear();
-        }
     }
 }
 

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -244,9 +244,21 @@ void get_ip_str(
 {
     if(sa)
     {
+        int addrlen = sizeof(sockaddr_in);
+        if (AF_INET6 == sa->sa_family)
+        {
+            addrlen = sizeof(sockaddr_in6);
+        }
+
         char to_ret[NI_MAXHOST];
-        getnameinfo(sa, sizeof (struct sockaddr), to_ret, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
-        result = to_ret;
+        if (0 == getnameinfo(sa, addrlen, to_ret, NI_MAXHOST, NULL, 0, NI_NUMERICHOST))
+        {
+            result = to_ret;
+        }
+        else
+        {
+            result.clear();
+        }
     }
 }
 


### PR DESCRIPTION
sockaddr_in (IPv4) is the same size as sockaddr, which is why getnameinfo() is working for IPv4. But sockaddr_in6 (IPv6) is larger than sockaddr, which is why getnameinfo() fails.