### PR TITLE
Added g++-8, clang6 and clang7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -263,6 +263,7 @@ matrix:
         apt:
           sources:
             - llvm-toolchain-trusty-6.0
+            - ubuntu-toolchain-r-test
           packages:
             - clang-6.0
       env:
@@ -272,6 +273,7 @@ matrix:
         apt:
           sources:
             - llvm-toolchain-trusty-7
+            - ubuntu-toolchain-r-test
           packages:
             - clang-7.0
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -275,7 +275,7 @@ matrix:
             - llvm-toolchain-trusty-7
             - ubuntu-toolchain-r-test
           packages:
-            - clang-7.0
+            - clang-7
       env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -264,7 +264,7 @@ matrix:
           sources:
             - llvm-toolchain-trusty-6.0
           packages:
-            - clang-5.0
+            - clang-6.0
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
     - os: linux
@@ -273,7 +273,7 @@ matrix:
           sources:
             - llvm-toolchain-trusty-7
           packages:
-            - clang-5.0
+            - clang-7.0
       env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -170,6 +170,15 @@ matrix:
             - g++-7
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
     #- os: osx
     #  osx_image: xcode8
     #  env:
@@ -249,6 +258,24 @@ matrix:
             - clang-5.0
       env:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-6.0
+          packages:
+            - clang-5.0
+      env:
+        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-7
+          packages:
+            - clang-5.0
+      env:
+        - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
     - os: linux
       compiler: clang
       addons:


### PR DESCRIPTION
### Description of the Change

Enabling test compilation on g++8, clang6 and clang7

### Benefits

It allows validating if the library can compile on the most modern platforms.

### Possible Drawbacks

It might incur in failure to build in travis.

### Verification Process

A build on travis will demonstrate if the change works or not.

### Release Notes

Enabled test compilation on g++8, clang6 and clang7