### PR TITLE
Travis independent commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,13 +82,11 @@ script:
        qemu-arm -L /usr/arm-linux-gnueabi/ ./.libs/http_utils ;
        qemu-arm -L /usr/arm-linux-gnueabi/ ./.libs/threaded ;
      fi
-   else
-     make check ;
-     cat test/test-suite.log ;
-     ls -l /usr/local/lib/ ;
-     ls -l /usr/lib/ ;
-     if [ "$TRAVIS_OS_NAME" = "linux" ]; then cd ../src/; cppcheck --error-exitcode=1 .; cd ../build; fi
-   fi
+ - make check
+ - cat test/test-suite.log
+ - ls -l /usr/local/lib/
+ - ls -l /usr/lib/
+ - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cd ../src/; cppcheck --error-exitcode=1 .; cd ../build; fi
 after_success:
   - if [ "$DEBUG" = "debug" ] && [ "$COVERAGE" = "coverage" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then bash <(curl -s https://codecov.io/bash); fi
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ script:
        qemu-arm -L /usr/arm-linux-gnueabi/ ./.libs/http_utils ;
        qemu-arm -L /usr/arm-linux-gnueabi/ ./.libs/threaded ;
      fi
+   fi
  - make check
  - cat test/test-suite.log
  - ls -l /usr/local/lib/

--- a/configure.ac
+++ b/configure.ac
@@ -270,6 +270,8 @@ if test x"$coverit" = x"yes"; then
     case $host_os in
         darwin* )
             echo "Coverage not supported on OSX"
+            AM_CXXFLAGS="$AM_CXXFLAGS -DDARWIN"
+            AM_CFLAGS="$AM_CFLAGS -DDARWIN"
             cond_gcov="no"
             ;;
         *)

--- a/configure.ac
+++ b/configure.ac
@@ -258,6 +258,13 @@ else
     AM_CFLAGS="$AM_CXXFLAGS -O3"
 fi
 
+case $host_os in
+    darwin* )
+        AM_CXXFLAGS="$AM_CXXFLAGS -DDARWIN"
+        AM_CFLAGS="$AM_CFLAGS -DDARWIN"
+        ;;
+esac
+
 AC_MSG_CHECKING([whether to build with coverage information])
 AC_ARG_ENABLE([coverage],
     [AS_HELP_STRING([--enable-coverage],
@@ -270,8 +277,6 @@ if test x"$coverit" = x"yes"; then
     case $host_os in
         darwin* )
             echo "Coverage not supported on OSX"
-            AM_CXXFLAGS="$AM_CXXFLAGS -DDARWIN"
-            AM_CFLAGS="$AM_CFLAGS -DDARWIN"
             cond_gcov="no"
             ;;
         *)

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -241,6 +241,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, enable_options)
 LT_END_AUTO_TEST(enable_options)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_socket)
+#ifndef DARWIN
     int fd = socket(AF_INET, SOCK_STREAM, 0);
 
     struct sockaddr_in address;
@@ -269,6 +270,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_socket)
     curl_easy_cleanup(curl);
 
     ws.stop();
+#endif
 LT_END_AUTO_TEST(custom_socket)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, single_resource)


### PR DESCRIPTION
### Description of the Change

Change travis script to run steps independently. Fails if any of the steps fails.

### Benefits

The main benefit is that, with this, it is possible to verify single steps rather than groups.

### Possible Drawbacks

Travis might fail while building.

### Verification Process

Performed tests on travis.

### Release Notes

Fixed multiple steps in travis being tested in groups