### PR TITLE
Making examples building optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,8 +24,14 @@ LIBTOOL_DEPS = @LIBTOOL_DEPS@
 AUTOMAKE_OPTIONS = foreign 1.4
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src test examples
-DIST_SUBDIRS = src test examples
+SUBDIRS = src test
+DIST_SUBDIRS = src test
+
+if BUILD_EXAMPLES
+SUBDIRS += examples
+DIST_SUBDIRS += examples
+endif
+
 EXTRA_DIST = libhttpserver.pc.in $(DX_CONFIG)
 
 MOSTLYCLEANFILES = $(DX_CLEANFILES) *.gcda *.gcno *.gcov

--- a/configure.ac
+++ b/configure.ac
@@ -286,6 +286,12 @@ if test x"$coverit" = x"yes"; then
     esac
 fi
 
+AC_ARG_ENABLE([[examples]],
+  [AS_HELP_STRING([[--disable-examples]], [do not build any examples])], ,
+    [enable_examples=yes])
+test "x$enable_examples" = "xno" || enable_examples=yes
+AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$enable_examples" = "xyes"])
+
 if test "$CROSS_COMPILE" == "1"; then
     if test "$ARM_ARCH_DIR" == "aarch64-linux-gnu"; then
         AM_CXXFLAGS="$AM_CXXFLAGS --prefix=${ARM_LD_PATH}/"
@@ -355,4 +361,5 @@ AC_MSG_NOTICE([Configuration Summary:
   poll support    :  ${enable_poll=no}
   epoll support   :  ${enable_epoll=no}
   Static          :  ${static}
+  Build examples  :  ${enable_examples}
 ])


### PR DESCRIPTION
### Description of the Change

This change makes the compilation of the "examples" optionally disabled.

### Quantitative Performance Benefits

This saves the builder from having to build examples if not interested

### Possible Drawbacks

None foreseeable.

### Verification Process

Travis runs.

### Applicable Issues

https://github.com/etr/libhttpserver/issues/61

### Release Notes

"examples" are now optionally disabled.

