### PR TITLE
Reduce regex usage

### DIFF
--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -223,7 +223,11 @@ std::vector<std::string> http_utils::tokenize_url(
 
 std::string http_utils::standardize_url(const std::string& url)
 {
-    std::string n_url = string_utilities::regex_replace(url, "(\\/)+", "/");
+    std::string n_url = url;
+
+    std::string::iterator new_end = std::unique(n_url.begin(), n_url.end(), [](char a, char b) { return (a == b) && (a == ' '); });
+    n_url.erase(new_end, n_url.end());
+
     std::string::size_type n_url_length = n_url.length();
 
     std::string result;

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -225,7 +225,7 @@ std::string http_utils::standardize_url(const std::string& url)
 {
     std::string n_url = url;
 
-    std::string::iterator new_end = std::unique(n_url.begin(), n_url.end(), [](char a, char b) { return (a == b) && (a == ' '); });
+    std::string::iterator new_end = std::unique(n_url.begin(), n_url.end(), [](char a, char b) { return (a == b) && (a == '/'); });
     n_url.erase(new_end, n_url.end());
 
     std::string::size_type n_url_length = n_url.length();

--- a/test/unit/http_utils_test.cpp
+++ b/test/unit/http_utils_test.cpp
@@ -128,6 +128,10 @@ LT_BEGIN_AUTO_TEST(http_utils_suite, standardize_url)
     url = "/abc/pqr", result = "";
     result = http::http_utils::standardize_url(url);
     LT_CHECK_EQ(result, "/abc/pqr");
+
+    url = "/abc//pqr", result = "";
+    result = http::http_utils::standardize_url(url);
+    LT_CHECK_EQ(result, "/abc/pqr");
 LT_END_AUTO_TEST(standardize_url)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, ip_to_str)


### PR DESCRIPTION
### Description of the Change
Removed frequent call to regex compile - thus saving CPU time. This was discovered through callgrind that pointed at regex compilation happening during URL normalization. The resulting code improves average time to serve requests by ~15% (during the load tests performed as part of the travis builds) and ~50% improvement in TP99 on INTERNAL_SELECT.

### Quantitative Performance Benefits
It is possible to observe the performance improvement in output of the following travis builds:
* Baseline (INTERNAL_SELECT): https://travis-ci.org/etr/libhttpserver/jobs/482289425

  50%      5
  66%      5
  75%      6
  80%      7
  90%      8
  95%     10
  98%     13
  99%     13
 100%     25 (longest request)

* New version (INTERNAL SELECT): https://travis-ci.org/etr/libhttpserver/jobs/482774149

  50%      5
  66%      5
  75%      5
  80%      5
  90%      5
  95%      6
  98%      6
  99%      7
 100%     21 (longest request)

* Baseline (THREAD_PER_CONNECTION): https://travis-ci.org/etr/libhttpserver/jobs/482289426

  50%     11
  66%     12
  75%     12
  80%     13
  90%     14
  95%     15
  98%     18
  99%     20
 100%    365 (longest request)

* New version (THREAD_PER_CONNECTION): https://travis-ci.org/etr/libhttpserver/jobs/482774150

  50%      8
  66%      9
  75%     10
  80%     10
  90%     12
  95%     14
  98%     18
  99%     21
 100%    202 (longest request)

### Possible Drawbacks

None real.

### Verification Process

Tested using travis.

### Applicable Issues

None

### Release Notes
Reduced the CPU time spent in normalizing URLs (thus saving ~15% on average per request).