### PR TITLE
Add private data support for deferred_response

### DIFF
--- a/src/deferred_response.cpp
+++ b/src/deferred_response.cpp
@@ -30,7 +30,8 @@ namespace details
 
 ssize_t cb(void* cls, uint64_t pos, char* buf, size_t max)
 {
-    ssize_t val = static_cast<deferred_response*>(cls)->cycle_callback(buf, max);
+    ssize_t val = static_cast<deferred_response*>(cls)->cycle_callback(
+                  static_cast<deferred_response*>(cls)->priv_data, buf, max);
     if(val == -1)
     {
         static_cast<deferred_response*>(cls)->completed = true;

--- a/test/integ/deferred.cpp
+++ b/test/integ/deferred.cpp
@@ -47,7 +47,7 @@ size_t writefunc(void *ptr, size_t size, size_t nmemb, std::string *s)
 
 static int counter = 0;
 
-ssize_t test_callback (char* buf, size_t max)
+ssize_t test_callback (void*, char* buf, size_t max)
 {
     if (counter == 2)
     {
@@ -67,7 +67,8 @@ class deferred_resource : public http_resource
     public:
         const shared_ptr<http_response> render_GET(const http_request& req)
         {
-            return shared_ptr<deferred_response>(new deferred_response(test_callback, "cycle callback response"));
+            return shared_ptr<deferred_response>(new deferred_response(test_callback, nullptr, nullptr,
+                                                                       "cycle callback response"));
         }
 };
 


### PR DESCRIPTION
This is a PR for additional private data support for deferred_response, it is necessary to carry private information so that cycle_callback could tell different HTTP connections by the customized data. cleanup_callback is used to clean up private data allocated by users.