### PR TITLE
Remove unused cleaner and select

### DIFF
--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -189,9 +189,6 @@ class webserver
 
         struct MHD_Daemon* daemon;
 
-        static void* select(void* self);
-        static void* cleaner(void* self);
-
         const std::shared_ptr<http_response> method_not_allowed_page(details::modded_request* mr) const;
         const std::shared_ptr<http_response> internal_error_page(details::modded_request* mr, bool force_our = false) const;
         const std::shared_ptr<http_response> not_found_page(details::modded_request* mr) const;


### PR DESCRIPTION
### Identify the Bug
Unused methods defined in the webserver class

### Description of the Change
Removed the unused methods

### Verification Process
Travis tests

### Release Notes
Removed unused "select" and "cleaner" from the definition of webserver.