### PR TITLE
Fixing compiler package for clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -288,8 +288,6 @@ matrix:
     - os: linux
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-4.0
           packages:
             - clang-4.0
       env:
@@ -298,8 +296,6 @@ matrix:
     - os: linux
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
           packages:
             - clang-5.0
       env:
@@ -307,9 +303,6 @@ matrix:
     - os: linux
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-6.0
-            - ubuntu-toolchain-r-test
           packages:
             - clang-6.0
       env:
@@ -318,12 +311,22 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-trusty-7
+            - llvm-toolchain-xenial-7
             - ubuntu-toolchain-r-test
           packages:
             - clang-7
       env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-xenial-8
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-8
+      env:
+        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
     - os: linux
       compiler: clang
       addons:


### PR DESCRIPTION
hotfix.

Travis has moved to xenial so all the packages referring to specific trusty toolchains are failing. This change aims to fix it by moving to specific xenial toolchains.