### PR TITLE
Simplify the cross-compilation build scripts.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,12 +24,18 @@ LIBTOOL_DEPS = @LIBTOOL_DEPS@
 AUTOMAKE_OPTIONS = foreign 1.4
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src test
-DIST_SUBDIRS = src test
+SUBDIRS = src
+DIST_SUBDIRS = src
+
+if !COND_CROSS_COMPILE
+SUBDIRS += test
+DIST_SUBDIRS += test
 
 if BUILD_EXAMPLES
 SUBDIRS += examples
 DIST_SUBDIRS += examples
+endif
+
 endif
 
 EXTRA_DIST = libhttpserver.pc.in $(DX_CONFIG)

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ AX_VALGRIND_CHECK
 OLD_CXXFLAGS=$CXXFLAGS
 LT_INIT
 AC_PROG_CC
-AC_PROG_CXX([clang++])
+AC_PROG_CXX()
 AC_PROG_LN_S
 CXXFLAGS=$OLD_CXXFLAGS
 AC_LANG([C++])
@@ -93,28 +93,48 @@ AC_CHECK_HEADER([signal.h],[],[AC_MSG_ERROR("signal.h not found")])
 AC_CHECK_HEADER([gnutls/gnutls.h],[have_gnutls="yes"],[AC_MSG_WARN("gnutls/gnutls.h not found. TLS will be disabled"); have_gnutls="no"])
 
 # Checks for libmicrohttpd
-AC_CHECK_HEADER([microhttpd.h],
-    AC_CHECK_LIB([microhttpd], [MHD_get_fdset2],
-        [AC_MSG_CHECKING([for libmicrohttpd >= 0.9.52])
-            AC_COMPILE_IFELSE(
-                [AC_LANG_SOURCE([
-                    #include <microhttpd.h>
-                    #if (MHD_VERSION < 0x00095102)
-                    #error needs at least version 0.9.52
-                    #endif
-                    int main () { return 0; }
-                ])],
-            [],
-            [AC_MSG_ERROR("libmicrohttpd is too old - install libmicrohttpd >= 0.9.52")]
-            )
-        ],
-        [AC_MSG_ERROR(["libmicrohttpd not found"])]
-    ),
-    [AC_MSG_ERROR(["microhttpd.h not found"])]
-)
+if test x"$host" = x"$build"; then
+    AC_CHECK_HEADER([microhttpd.h],
+        AC_CHECK_LIB([microhttpd], [MHD_get_fdset2],
+            [AC_MSG_CHECKING([for libmicrohttpd >= 0.9.52])
+                AC_COMPILE_IFELSE(
+                    [AC_LANG_SOURCE([
+                        #include <microhttpd.h>
+                        #if (MHD_VERSION < 0x00095102)
+                        #error needs at least version 0.9.52
+                        #endif
+                        int main () { return 0; }
+                    ])],
+                [],
+                [AC_MSG_ERROR("libmicrohttpd is too old - install libmicrohttpd >= 0.9.52")]
+                )
+            ],
+            [AC_MSG_ERROR(["libmicrohttpd not found"])]
+        ),
+        [AC_MSG_ERROR(["microhttpd.h not found"])]
+    )
 
-CXXFLAGS="-std=c++11 -DHTTPSERVER_COMPILATION -D_REENTRANT $LIBMICROHTTPD_CFLAGS $CXXFLAGS"
-LDFLAGS="$LIBMICROHTTPD_LIBS $REGEX_LIBS $LDFLAGS"
+    CXXFLAGS="-std=c++11 -DHTTPSERVER_COMPILATION -D_REENTRANT $LIBMICROHTTPD_CFLAGS $CXXFLAGS"
+    LDFLAGS="$LIBMICROHTTPD_LIBS $REGEX_LIBS $LDFLAGS"
+
+    cond_cross_compile="no"
+else
+    AC_CHECK_HEADER([microhttpd.h],
+        AC_CHECK_LIB([microhttpd], [MHD_get_fdset2],
+            [],
+            [AC_MSG_ERROR(["libmicrohttpd not found"])]
+        ),
+        [AC_MSG_ERROR(["microhttpd.h not found"])]
+    )
+
+    CXXFLAGS="-std=c++11 -DHTTPSERVER_COMPILATION -D_REENTRANT $CXXFLAGS"
+    LDFLAGS="$REGEX_LIBS $LDFLAGS"
+
+    cond_cross_compile="yes"
+fi
+
+AM_CONDITIONAL([COND_CROSS_COMPILE],[test x"$cond_cross_compile" = x"yes"])
+AC_SUBST(COND_CROSS_COMPILE)
 
 AC_MSG_CHECKING([whether to build with TCP_FASTOPEN support])
 AC_ARG_ENABLE([fastopen],
@@ -291,18 +311,6 @@ AC_ARG_ENABLE([[examples]],
     [enable_examples=yes])
 test "x$enable_examples" = "xno" || enable_examples=yes
 AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$enable_examples" = "xyes"])
-
-if test "$CROSS_COMPILE" == "1"; then
-    if test "$ARM_ARCH_DIR" == "aarch64-linux-gnu"; then
-        AM_CXXFLAGS="$AM_CXXFLAGS --prefix=${ARM_LD_PATH}/"
-        AM_CFLAGS="$AM_CFLAGS --prefix=${ARM_LD_PATH}/"
-        PATH="${ARM_LD_PATH}/:$PATH"
-        CXXLINK="${ARM_LD_PATH}/ld"
-        LINK="${ARM_LD_PATH}/ld"
-        LD="${ARM_LD_PATH}/ld"
-        LDFLAGS="$LDFLAGS -Wl,-rpath -Wl,/usr/lib -Wl,-rpath-link -Wl,${ARM_LD_PATH}/usr/lib -L${ARM_LD_PATH}/lib -L${ARM_LD_PATH}/usr/lib"
-    fi
-fi
 
 AM_CONDITIONAL([COND_GCOV],[test x"$cond_gcov" = x"yes"])
 AC_SUBST(COND_GCOV)

--- a/libhttpserver.pc.in
+++ b/libhttpserver.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@
 Name: libhttpserver
 Description: A C++ library for creating an embedded Rest HTTP server
 Version: @VERSION@
-Requires: libmicrohttpd >= 0.9.37
+Requires: libmicrohttpd >= 0.9.52
 Conflicts:
 Libs: -L${libdir} -lhttpserver
 Libs.private: @LHT_LIBDEPS@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,7 +31,10 @@ AM_CXXFLAGS += -O0 --coverage --no-inline
 AM_LDFLAGS += -O0 --coverage -lgcov --no-inline
 endif
 
+if !COND_CROSS_COMPILE
 libhttpserver_la_LIBADD = -lmicrohttpd
+endif
+
 libhttpserver_la_CFLAGS = $(AM_CFLAGS)
 libhttpserver_la_CXXFLAGS = $(AM_CXXFLAGS)
 libhttpserver_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined


### PR DESCRIPTION
### Description of the Change

This change simplifies the checks performed during cross-compilation by removing the compile-and-check performed on libmicrohttpd (which cannot work due to the different binary format)

### Possible Drawbacks

This might lead to errors during compilation/linking if the wrong version of libmicrohttpd is used

### Verification Process
Unit tests / Integration tests

### Release Notes

Removed version checks on libmicrohttpd when cross-compiling.