### PR TITLE
Adapted sleep function in 'examples/deferred_with_accumulator.cpp' for non-*Nix

### DIFF
--- a/examples/deferred_with_accumulator.cpp
+++ b/examples/deferred_with_accumulator.cpp
@@ -18,6 +18,8 @@
      USA
 */
 
+#include <chrono>
+#include <thread>
 #include <atomic>
 #include <httpserver.hpp>
 
@@ -44,7 +46,8 @@ ssize_t test_callback (std::shared_ptr<std::atomic<int> > closure_data, char* bu
         std::copy(str.begin(), str.end(), buf);
 
         // keep sending reqid
-        sleep(1);
+        // sleep(1); ==> adapted for C++11 on non-*Nix systems
+        std::this_thread::sleep_for(std::chrono::seconds(1));
 
         return (ssize_t)max;
     }


### PR DESCRIPTION
### Identify the Bug

https://github.com/etr/libhttpserver/issues/156

### Description of the Change

Modified deferred_with_accumulator.cpp example
Added thread, chrono headers. Changed sleep() function to C++11

### Alternate Designs

#ifdef Windows hack: https://stackoverflow.com/a/10918411/234826

### Possible Drawbacks

Might add infinitesimal overhead for Unix systems compared to using straight sleep()

### Verification Process

Checked on MinGW64 and Ubuntu x64

### Release Notes

Replaced sleep function with C++11 equivalent.