### PR TITLE
Added Winsock2 library for mingw; Not tested for cygwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,10 +60,12 @@ if test x"$samedirectory" = x"no"; then
 fi
 
 is_windows=yes;
+NETWORK_LIBS=""
 case "$host" in
     *-mingw*)
         NETWORK_HEADER="winsock2.h"
         REGEX_LIBS="-lregex -lpthread -no-undefined"
+        NETWORK_LIBS="-lws2_32"
         native_srcdir=$(cd $srcdir; pwd -W)
         ;;
     *-cygwin*)
@@ -115,7 +117,7 @@ if test x"$host" = x"$build"; then
     )
 
     CXXFLAGS="-std=c++11 -DHTTPSERVER_COMPILATION -D_REENTRANT $LIBMICROHTTPD_CFLAGS $CXXFLAGS"
-    LDFLAGS="$LIBMICROHTTPD_LIBS $REGEX_LIBS $LDFLAGS"
+    LDFLAGS="$LIBMICROHTTPD_LIBS $NETWORK_LIBS $REGEX_LIBS $LDFLAGS"
 
     cond_cross_compile="no"
 else
@@ -128,7 +130,7 @@ else
     )
 
     CXXFLAGS="-std=c++11 -DHTTPSERVER_COMPILATION -D_REENTRANT $CXXFLAGS"
-    LDFLAGS="$REGEX_LIBS $LDFLAGS"
+    LDFLAGS="$NETWORK_LIBS $REGEX_LIBS $LDFLAGS"
 
     cond_cross_compile="yes"
 fi


### PR DESCRIPTION
### Identify the Bug

https://github.com/etr/libhttpserver/issues/74

### Description of the Change

Added NETWORK_LIBS variable in **configure.ac** at CASE **$host**.
Added NETWORK_LIBS="-lws2_32" to mingw CASE
Added $NETWORK_LIBS to LDFLAGS before $REGEX_LIBS for both compile/cross-compile

### Alternate Designs

Adding -lws2_32 to Cygwin CYGWIN, but I haven't confirmed it needs it.
Adding -lws2_32 to REGEX_LIBS but that felt dishonest even though it's the easier option.

### Possible Drawbacks

One MORE variable in configure.ac to keep track of.

### Verification Process

Tested on MSYS/MinGW64, Ubuntu 19.04x64
Initial tests on Cygwin are failing on WinSock2 header test, but I may have "corrupted" my install by installing the mingw64-x86_64-gcc toolchain in Cygwin.

### Release Notes
Fixes the linking failure in Issue 74 for MinGW targets.

