### PR TITLE
Add fix to get_path_pieces to return by value.

### DIFF
--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -93,7 +93,7 @@ class http_request
          * @param index the index of the piece selected
          * @return the selected piece in form of string
         **/
-        const std::string& get_path_piece(int index) const
+        const std::string get_path_piece(int index) const
         {
             std::vector<std::string> post_path = this->get_path_pieces();
             if(((int)(post_path.size())) > index)


### PR DESCRIPTION
### Identify the Bug

https://github.com/etr/libhttpserver/issues/159

### Description of the Change

Add fix to get_path_pieces to return by value

### Verification Process

Unit tests and manual testing

### Release Notes

Added fix to get_path_pieces to return by value