### PR TITLE
Fixes get pending when body is provided.

### DIFF
--- a/src/httpserver/details/modded_request.hpp
+++ b/src/httpserver/details/modded_request.hpp
@@ -43,6 +43,7 @@ struct modded_request
     http_request* dhr;
     std::shared_ptr<http_response> dhrs;
     bool second;
+    bool has_body;
 
     modded_request():
         pp(0x0),
@@ -50,7 +51,8 @@ struct modded_request
         standardized_url(0x0),
         ws(0x0),
         dhr(0x0),
-        second(false)
+        second(false),
+        has_body(false)
     {
     }
 
@@ -60,7 +62,8 @@ struct modded_request
         standardized_url(b.standardized_url),
         ws(b.ws),
         dhr(b.dhr),
-        second(b.second)
+        second(b.second),
+        has_body(b.has_body)
     {
     }
 
@@ -70,7 +73,8 @@ struct modded_request
         standardized_url(std::move(b.standardized_url)),
         ws(std::move(b.ws)),
         dhr(std::move(b.dhr)),
-        second(b.second)
+        second(b.second),
+        has_body(b.has_body)
     {
     }
 
@@ -84,6 +88,7 @@ struct modded_request
         this->ws = b.ws;
         this->dhr = b.dhr;
         this->second = b.second;
+        this->has_body = b.has_body;
 
         return *this;
     }
@@ -98,6 +103,7 @@ struct modded_request
         this->ws = std::move(b.ws);
         this->dhr = std::move(b.dhr);
         this->second = b.second;
+        this->has_body = b.has_body;
 
         return *this;
     }

--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -222,16 +222,11 @@ class webserver
             void **con_cls, int upgrade_socket
         );
 
-        int bodyless_requests_answer(MHD_Connection* connection,
-            const char* method, const char* version,
-            struct details::modded_request* mr
-        );
-
-        int bodyfull_requests_answer_first_step(MHD_Connection* connection,
+        int requests_answer_first_step(MHD_Connection* connection,
                 struct details::modded_request* mr
         );
 
-        int bodyfull_requests_answer_second_step(MHD_Connection* connection,
+        int requests_answer_second_step(MHD_Connection* connection,
             const char* method, const char* version, const char* upload_data,
             size_t* upload_data_size, struct details::modded_request* mr
         );


### PR DESCRIPTION
### Identify the Bug

As notified in: https://github.com/etr/libhttpserver/pull/165

The webserver hangs the request without terminating if the request is a body-less one (e.g. GET-like) but provides a body.

### Description of the Change

This change allows the webserver to process the request without failing.

### Alternate Designs

The linked pull-request presents a design that actively parses and processes the body passed in input. This implementation chooses to discard it instead.

### Possible Drawbacks

Main drawback of this choice is not to process the body to adhere to a strict semantic (GET not providing a body). This limits use-cases that might require a body to be provided on GET requests. See motivation in the thread here: https://github.com/etr/libhttpserver/pull/165

### Verification Process

Unit and Integration tests

### Release Notes

Fixed bug that made the webserver hang the request without terminating if the request was a body-less one (e.g. GET-like) but provided a body.