### PR TITLE
Add test build on gcc-9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -247,6 +247,15 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - g++-9
+      env:
+        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
             - g++-7
             - valgrind
             - valgrind-dbg


### PR DESCRIPTION
No change to the library itself. Added auto-build for gcc-9 on travis.