### PR TITLE
Use =default for constructors and operator= where possible

### DIFF
--- a/src/httpserver/basic_auth_fail_response.hpp
+++ b/src/httpserver/basic_auth_fail_response.hpp
@@ -49,7 +49,7 @@ class basic_auth_fail_response : public string_response
         basic_auth_fail_response(const basic_auth_fail_response& other) = default;
         basic_auth_fail_response(basic_auth_fail_response&& other) noexcept = default;
         basic_auth_fail_response& operator=(const basic_auth_fail_response& b) = default;
-        basic_auth_fail_response& operator=(basic_auth_fail_response&& b) noexcept = default;
+        basic_auth_fail_response& operator=(basic_auth_fail_response&& b) = default;
 
         ~basic_auth_fail_response() = default;
 

--- a/src/httpserver/basic_auth_fail_response.hpp
+++ b/src/httpserver/basic_auth_fail_response.hpp
@@ -33,11 +33,7 @@ namespace httpserver
 class basic_auth_fail_response : public string_response
 {
     public:
-        basic_auth_fail_response():
-            string_response(),
-            realm("")
-        {
-        }
+        basic_auth_fail_response() = default;
 
         explicit basic_auth_fail_response(
                 const std::string& content,
@@ -50,46 +46,17 @@ class basic_auth_fail_response : public string_response
         {
         }
 
-        basic_auth_fail_response(const basic_auth_fail_response& other):
-            string_response(other),
-            realm(other.realm)
-        {
-        }
+        basic_auth_fail_response(const basic_auth_fail_response& other) = default;
+        basic_auth_fail_response(basic_auth_fail_response&& other) noexcept = default;
+        basic_auth_fail_response& operator=(const basic_auth_fail_response& b) = default;
+        basic_auth_fail_response& operator=(basic_auth_fail_response&& b) noexcept = default;
 
-        basic_auth_fail_response(basic_auth_fail_response&& other) noexcept:
-            string_response(std::move(other)),
-            realm(std::move(other.realm))
-        {
-        }
-
-        basic_auth_fail_response& operator=(const basic_auth_fail_response& b)
-        {
-            if (this == &b) return *this;
-
-            (string_response&) (*this) = b;
-            this->realm = b.realm;
-
-            return *this;
-        }
-
-        basic_auth_fail_response& operator=(basic_auth_fail_response&& b)
-        {
-            if (this == &b) return *this;
-
-            (string_response&) (*this) = std::move(b);
-            this->realm = std::move(b.realm);
-
-            return *this;
-        }
-
-        ~basic_auth_fail_response()
-        {
-        }
+        ~basic_auth_fail_response() = default;
 
         int enqueue_response(MHD_Connection* connection, MHD_Response* response);
 
     private:
-        std::string realm;
+        std::string realm = "";
 };
 
 }

--- a/src/httpserver/create_webserver.hpp
+++ b/src/httpserver/create_webserver.hpp
@@ -25,6 +25,7 @@
 #ifndef _CREATE_WEBSERVER_HPP_
 #define _CREATE_WEBSERVER_HPP_
 
+#include <limits>
 #include <stdlib.h>
 #include "httpserver/http_utils.hpp"
 #include "httpserver/http_response.hpp"
@@ -45,263 +46,14 @@ typedef void(*log_error_ptr)(const std::string&);
 class create_webserver
 {
     public:
-        create_webserver():
-            _port(DEFAULT_WS_PORT),
-            _start_method(http::http_utils::INTERNAL_SELECT),
-            _max_threads(0),
-            _max_connections(0),
-            _memory_limit(0),
-            _content_size_limit(static_cast<size_t>(-1)),
-            _connection_timeout(DEFAULT_WS_TIMEOUT),
-            _per_IP_connection_limit(0),
-            _log_access(0x0),
-            _log_error(0x0),
-            _validator(0x0),
-            _unescaper(0x0),
-            _bind_address(0x0),
-            _bind_socket(0),
-            _max_thread_stack_size(0),
-            _use_ssl(false),
-            _use_ipv6(false),
-            _debug(false),
-            _pedantic(false),
-            _https_mem_key(""),
-            _https_mem_cert(""),
-            _https_mem_trust(""),
-            _https_priorities(""),
-            _cred_type(http::http_utils::NONE),
-            _digest_auth_random(""),
-            _nonce_nc_size(0),
-            _default_policy(http::http_utils::ACCEPT),
-            _basic_auth_enabled(true),
-            _digest_auth_enabled(true),
-            _regex_checking(true),
-            _ban_system_enabled(true),
-            _post_process_enabled(true),
-            _deferred_enabled(false),
-            _single_resource(false),
-            _tcp_nodelay(false),
-            _not_found_resource(0x0),
-            _method_not_allowed_resource(0x0),
-            _internal_error_resource(0x0)
-        {
-        }
-
-        create_webserver(const create_webserver& b):
-            _port(b._port),
-            _start_method(b._start_method),
-            _max_threads(b._max_threads),
-            _max_connections(b._max_connections),
-            _memory_limit(b._memory_limit),
-            _content_size_limit(b._content_size_limit),
-            _connection_timeout(b._connection_timeout),
-            _per_IP_connection_limit(b._per_IP_connection_limit),
-            _log_access(b._log_access),
-            _log_error(b._log_error),
-            _validator(b._validator),
-            _unescaper(b._unescaper),
-            _bind_address(b._bind_address),
-            _bind_socket(b._bind_socket),
-            _max_thread_stack_size(b._max_thread_stack_size),
-            _use_ssl(b._use_ssl),
-            _use_ipv6(b._use_ipv6),
-            _debug(b._debug),
-            _pedantic(b._pedantic),
-            _https_mem_key(b._https_mem_key),
-            _https_mem_cert(b._https_mem_cert),
-            _https_mem_trust(b._https_mem_trust),
-            _https_priorities(b._https_priorities),
-            _cred_type(b._cred_type),
-            _digest_auth_random(b._digest_auth_random),
-            _nonce_nc_size(b._nonce_nc_size),
-            _default_policy(b._default_policy),
-            _basic_auth_enabled(b._basic_auth_enabled),
-            _digest_auth_enabled(b._digest_auth_enabled),
-            _regex_checking(b._regex_checking),
-            _ban_system_enabled(b._ban_system_enabled),
-            _post_process_enabled(b._post_process_enabled),
-            _deferred_enabled(b._deferred_enabled),
-            _single_resource(b._single_resource),
-            _tcp_nodelay(b._tcp_nodelay),
-            _not_found_resource(b._not_found_resource),
-            _method_not_allowed_resource(b._method_not_allowed_resource),
-            _internal_error_resource(b._internal_error_resource)
-        {
-        }
-
-        create_webserver(create_webserver&& b):
-            _port(b._port),
-            _start_method(b._start_method),
-            _max_threads(b._max_threads),
-            _max_connections(b._max_connections),
-            _memory_limit(b._memory_limit),
-            _content_size_limit(b._content_size_limit),
-            _connection_timeout(b._connection_timeout),
-            _per_IP_connection_limit(b._per_IP_connection_limit),
-            _log_access(std::move(b._log_access)),
-            _log_error(std::move(b._log_error)),
-            _validator(std::move(b._validator)),
-            _unescaper(std::move(b._unescaper)),
-            _bind_address(std::move(b._bind_address)),
-            _bind_socket(b._bind_socket),
-            _max_thread_stack_size(b._max_thread_stack_size),
-            _use_ssl(b._use_ssl),
-            _use_ipv6(b._use_ipv6),
-            _debug(b._debug),
-            _pedantic(b._pedantic),
-            _https_mem_key(std::move(b._https_mem_key)),
-            _https_mem_cert(std::move(b._https_mem_cert)),
-            _https_mem_trust(std::move(b._https_mem_trust)),
-            _https_priorities(std::move(b._https_priorities)),
-            _cred_type(b._cred_type),
-            _digest_auth_random(std::move(b._digest_auth_random)),
-            _nonce_nc_size(b._nonce_nc_size),
-            _default_policy(b._default_policy),
-            _basic_auth_enabled(b._basic_auth_enabled),
-            _digest_auth_enabled(b._digest_auth_enabled),
-            _regex_checking(b._regex_checking),
-            _ban_system_enabled(b._ban_system_enabled),
-            _post_process_enabled(b._post_process_enabled),
-            _deferred_enabled(b._deferred_enabled),
-            _single_resource(b._single_resource),
-            _tcp_nodelay(b._tcp_nodelay),
-            _not_found_resource(std::move(b._not_found_resource)),
-            _method_not_allowed_resource(std::move(b._method_not_allowed_resource)),
-            _internal_error_resource(std::move(b._internal_error_resource))
-        {
-        }
-
-       create_webserver& operator=(const create_webserver& b)
-       {
-           if (this == &b) return *this;
-
-           this->_port = b._port;
-           this->_start_method = b._start_method;
-           this->_max_threads = b._max_threads;
-           this->_max_connections = b._max_connections;
-           this->_memory_limit = b._memory_limit;
-           this->_content_size_limit = b._content_size_limit;
-           this->_connection_timeout = b._connection_timeout;
-           this->_per_IP_connection_limit = b._per_IP_connection_limit;
-           this->_log_access = b._log_access;
-           this->_log_error = b._log_error;
-           this->_validator = b._validator;
-           this->_unescaper = b._unescaper;
-           this->_bind_address = b._bind_address;
-           this->_bind_socket = b._bind_socket;
-           this->_max_thread_stack_size = b._max_thread_stack_size;
-           this->_use_ssl = b._use_ssl;
-           this->_use_ipv6 = b._use_ipv6;
-           this->_debug = b._debug;
-           this->_pedantic = b._pedantic;
-           this->_https_mem_key = b._https_mem_key;
-           this->_https_mem_cert = b._https_mem_cert;
-           this->_https_mem_trust = b._https_mem_trust;
-           this->_https_priorities = b._https_priorities;
-           this->_cred_type = b._cred_type;
-           this->_digest_auth_random = b._digest_auth_random;
-           this->_nonce_nc_size = b._nonce_nc_size;
-           this->_default_policy = b._default_policy;
-           this->_basic_auth_enabled = b._basic_auth_enabled;
-           this->_digest_auth_enabled = b._digest_auth_enabled;
-           this->_regex_checking = b._regex_checking;
-           this->_ban_system_enabled = b._ban_system_enabled;
-           this->_post_process_enabled = b._post_process_enabled;
-           this->_deferred_enabled = b._deferred_enabled;
-           this->_single_resource = b._single_resource;
-           this->_tcp_nodelay = b._tcp_nodelay;
-           this->_not_found_resource = b._not_found_resource;
-           this->_method_not_allowed_resource = b._method_not_allowed_resource;
-           this->_internal_error_resource = b._internal_error_resource;
-
-           return *this;
-       }
-
-       create_webserver& operator=(create_webserver&& b)
-       {
-           if (this == &b) return *this;
-
-           this->_port = b._port;
-           this->_start_method = b._start_method;
-           this->_max_threads = b._max_threads;
-           this->_max_connections = b._max_connections;
-           this->_memory_limit = b._memory_limit;
-           this->_content_size_limit = b._content_size_limit;
-           this->_connection_timeout = b._connection_timeout;
-           this->_per_IP_connection_limit = b._per_IP_connection_limit;
-           this->_log_access = std::move(b._log_access);
-           this->_log_error = std::move(b._log_error);
-           this->_validator = std::move(b._validator);
-           this->_unescaper = std::move(b._unescaper);
-           this->_bind_address = std::move(b._bind_address);
-           this->_bind_socket = b._bind_socket;
-           this->_max_thread_stack_size = b._max_thread_stack_size;
-           this->_use_ssl = b._use_ssl;
-           this->_use_ipv6 = b._use_ipv6;
-           this->_debug = b._debug;
-           this->_pedantic = b._pedantic;
-           this->_https_mem_key = std::move(b._https_mem_key);
-           this->_https_mem_cert = std::move(b._https_mem_cert);
-           this->_https_mem_trust = std::move(b._https_mem_trust);
-           this->_https_priorities = std::move(b._https_priorities);
-           this->_cred_type = b._cred_type;
-           this->_digest_auth_random = std::move(b._digest_auth_random);
-           this->_nonce_nc_size = b._nonce_nc_size;
-           this->_default_policy = b._default_policy;
-           this->_basic_auth_enabled = b._basic_auth_enabled;
-           this->_digest_auth_enabled = b._digest_auth_enabled;
-           this->_regex_checking = b._regex_checking;
-           this->_ban_system_enabled = b._ban_system_enabled;
-           this->_post_process_enabled = b._post_process_enabled;
-           this->_deferred_enabled = b._deferred_enabled;
-           this->_single_resource = b._single_resource;
-           this->_tcp_nodelay = b._tcp_nodelay;
-           this->_not_found_resource = std::move(b._not_found_resource);
-           this->_method_not_allowed_resource = std::move(b._method_not_allowed_resource);
-           this->_internal_error_resource = std::move(b._internal_error_resource);
-
-           return *this;
-        }
+        create_webserver() = default;
+        create_webserver(const create_webserver& b) = default;
+        create_webserver(create_webserver&& b) noexcept = default;
+        create_webserver& operator=(const create_webserver& b) = default;
+        create_webserver& operator=(create_webserver&& b) noexcept = default;
 
         explicit create_webserver(uint16_t port):
-            _port(port),
-            _start_method(http::http_utils::INTERNAL_SELECT),
-            _max_threads(0),
-            _max_connections(0),
-            _memory_limit(0),
-            _content_size_limit(static_cast<size_t>(-1)),
-            _connection_timeout(DEFAULT_WS_TIMEOUT),
-            _per_IP_connection_limit(0),
-            _log_access(0x0),
-            _log_error(0x0),
-            _validator(0x0),
-            _unescaper(0x0),
-            _bind_address(0x0),
-            _bind_socket(0),
-            _max_thread_stack_size(0),
-            _use_ssl(false),
-            _use_ipv6(false),
-            _debug(false),
-            _pedantic(false),
-            _https_mem_key(""),
-            _https_mem_cert(""),
-            _https_mem_trust(""),
-            _https_priorities(""),
-            _cred_type(http::http_utils::NONE),
-            _digest_auth_random(""),
-            _nonce_nc_size(0),
-            _default_policy(http::http_utils::ACCEPT),
-            _basic_auth_enabled(true),
-            _digest_auth_enabled(true),
-            _regex_checking(true),
-            _ban_system_enabled(true),
-            _post_process_enabled(true),
-            _deferred_enabled(false),
-            _single_resource(false),
-            _tcp_nodelay(false),
-            _not_found_resource(0x0),
-            _method_not_allowed_resource(0x0),
-            _internal_error_resource(0x0)
+            _port(port)
         {
         }
 
@@ -500,44 +252,44 @@ class create_webserver
         }
 
     private:
-        uint16_t _port;
-        http::http_utils::start_method_T _start_method;
-        int _max_threads;
-        int _max_connections;
-        int _memory_limit;
-        size_t _content_size_limit;
-        int _connection_timeout;
-        int _per_IP_connection_limit;
-        log_access_ptr _log_access;
-        log_error_ptr _log_error;
-        validator_ptr _validator;
-        unescaper_ptr _unescaper;
-        const struct sockaddr* _bind_address;
-        int _bind_socket;
-        int _max_thread_stack_size;
-        bool _use_ssl;
-        bool _use_ipv6;
-        bool _debug;
-        bool _pedantic;
-        std::string _https_mem_key;
-        std::string _https_mem_cert;
-        std::string _https_mem_trust;
-        std::string _https_priorities;
-        http::http_utils::cred_type_T _cred_type;
-        std::string _digest_auth_random;
-        int _nonce_nc_size;
-        http::http_utils::policy_T _default_policy;
-        bool _basic_auth_enabled;
-        bool _digest_auth_enabled;
-        bool _regex_checking;
-        bool _ban_system_enabled;
-        bool _post_process_enabled;
-        bool _deferred_enabled;
-        bool _single_resource;
-        bool _tcp_nodelay;
-        render_ptr _not_found_resource;
-        render_ptr _method_not_allowed_resource;
-        render_ptr _internal_error_resource;
+        uint16_t _port = DEFAULT_WS_PORT;
+        http::http_utils::start_method_T _start_method = http::http_utils::INTERNAL_SELECT;
+        int _max_threads = 0;
+        int _max_connections = 0;
+        int _memory_limit = 0;
+        size_t _content_size_limit = std::numeric_limits<size_t>::max();
+        int _connection_timeout = DEFAULT_WS_TIMEOUT;
+        int _per_IP_connection_limit = 0;
+        log_access_ptr _log_access = nullptr;
+        log_error_ptr _log_error = nullptr;
+        validator_ptr _validator = nullptr;
+        unescaper_ptr _unescaper = nullptr;
+        const struct sockaddr* _bind_address = nullptr;
+        int _bind_socket = 0;
+        int _max_thread_stack_size = 0;
+        bool _use_ssl = false;
+        bool _use_ipv6 = false;
+        bool _debug = false;
+        bool _pedantic = false;
+        std::string _https_mem_key = "";
+        std::string _https_mem_cert = "";
+        std::string _https_mem_trust = "";
+        std::string _https_priorities = "";
+        http::http_utils::cred_type_T _cred_type = http::http_utils::NONE;
+        std::string _digest_auth_random = "";
+        int _nonce_nc_size = 0;
+        http::http_utils::policy_T _default_policy = http::http_utils::ACCEPT;
+        bool _basic_auth_enabled = true;
+        bool _digest_auth_enabled = true;
+        bool _regex_checking = true;
+        bool _ban_system_enabled = true;
+        bool _post_process_enabled = true;
+        bool _deferred_enabled = false;
+        bool _single_resource = false;
+        bool _tcp_nodelay = false;
+        render_ptr _not_found_resource = nullptr;
+        render_ptr _method_not_allowed_resource = nullptr;
+        render_ptr _internal_error_resource = nullptr;
 
         friend class webserver;
 };

--- a/src/httpserver/create_webserver.hpp
+++ b/src/httpserver/create_webserver.hpp
@@ -50,7 +50,7 @@ class create_webserver
         create_webserver(const create_webserver& b) = default;
         create_webserver(create_webserver&& b) noexcept = default;
         create_webserver& operator=(const create_webserver& b) = default;
-        create_webserver& operator=(create_webserver&& b) noexcept = default;
+        create_webserver& operator=(create_webserver&& b) = default;
 
         explicit create_webserver(uint16_t port):
             _port(port)

--- a/src/httpserver/create_webserver.hpp
+++ b/src/httpserver/create_webserver.hpp
@@ -25,7 +25,6 @@
 #ifndef _CREATE_WEBSERVER_HPP_
 #define _CREATE_WEBSERVER_HPP_
 
-#include <limits>
 #include <stdlib.h>
 #include "httpserver/http_utils.hpp"
 #include "httpserver/http_response.hpp"
@@ -257,14 +256,14 @@ class create_webserver
         int _max_threads = 0;
         int _max_connections = 0;
         int _memory_limit = 0;
-        size_t _content_size_limit = std::numeric_limits<size_t>::max();
+        size_t _content_size_limit = static_cast<size_t>(-1);
         int _connection_timeout = DEFAULT_WS_TIMEOUT;
         int _per_IP_connection_limit = 0;
-        log_access_ptr _log_access = nullptr;
-        log_error_ptr _log_error = nullptr;
-        validator_ptr _validator = nullptr;
-        unescaper_ptr _unescaper = nullptr;
-        const struct sockaddr* _bind_address = nullptr;
+        log_access_ptr _log_access = 0x0;
+        log_error_ptr _log_error = 0x0;
+        validator_ptr _validator = 0x0;
+        unescaper_ptr _unescaper = 0x0;
+        const struct sockaddr* _bind_address = 0x0;
         int _bind_socket = 0;
         int _max_thread_stack_size = 0;
         bool _use_ssl = false;
@@ -287,9 +286,9 @@ class create_webserver
         bool _deferred_enabled = false;
         bool _single_resource = false;
         bool _tcp_nodelay = false;
-        render_ptr _not_found_resource = nullptr;
-        render_ptr _method_not_allowed_resource = nullptr;
-        render_ptr _internal_error_resource = nullptr;
+        render_ptr _not_found_resource = 0x0;
+        render_ptr _method_not_allowed_resource = 0x0;
+        render_ptr _internal_error_resource = 0x0;
 
         friend class webserver;
 };

--- a/src/httpserver/deferred_response.hpp
+++ b/src/httpserver/deferred_response.hpp
@@ -53,45 +53,12 @@ class deferred_response : public string_response
         {
         }
 
-        deferred_response(const deferred_response& other):
-            string_response(other),
-            cycle_callback(other.cycle_callback),
-            closure_data(other.closure_data)
-        {
-        }
+        deferred_response(const deferred_response& other) = default;
+        deferred_response(deferred_response&& other) noexcept = default;
+        deferred_response& operator=(const deferred_response& b) = default;
+        deferred_response& operator=(deferred_response&& b) noexcept = default;
 
-        deferred_response(deferred_response&& other) noexcept:
-            string_response(std::move(other)),
-            cycle_callback(std::move(other.cycle_callback)),
-            closure_data(std::move(other.closure_data))
-        {
-        }
-
-        deferred_response& operator=(const deferred_response& b)
-        {
-            if (this == &b) return *this;
-
-            (string_response&) (*this) = b;
-            this->cycle_callback = b.cycle_callback;
-            this->closure_data = b.closure_data;
-
-            return *this;
-        }
-
-        deferred_response& operator=(deferred_response&& b)
-        {
-            if (this == &b) return *this;
-
-            (string_response&) (*this) = std::move(b);
-            this->cycle_callback = std::move(b.cycle_callback);
-            this->closure_data = std::move(b.closure_data);
-
-            return *this;
-        }
-
-        ~deferred_response()
-        {
-        }
+        ~deferred_response() = default;
 
         MHD_Response* get_raw_response()
         {

--- a/src/httpserver/deferred_response.hpp
+++ b/src/httpserver/deferred_response.hpp
@@ -56,7 +56,7 @@ class deferred_response : public string_response
         deferred_response(const deferred_response& other) = default;
         deferred_response(deferred_response&& other) noexcept = default;
         deferred_response& operator=(const deferred_response& b) = default;
-        deferred_response& operator=(deferred_response&& b) noexcept = default;
+        deferred_response& operator=(deferred_response&& b) = default;
 
         ~deferred_response() = default;
 

--- a/src/httpserver/details/modded_request.hpp
+++ b/src/httpserver/details/modded_request.hpp
@@ -33,80 +33,25 @@ namespace details
 
 struct modded_request
 {
-    struct MHD_PostProcessor *pp;
-    std::string* complete_uri;
-    std::string* standardized_url;
-    webserver* ws;
+    struct MHD_PostProcessor *pp = 0x0;
+    std::string* complete_uri = 0x0;
+    std::string* standardized_url = 0x0;
+    webserver* ws = 0x0;
 
     const std::shared_ptr<http_response> (httpserver::http_resource::*callback)(const httpserver::http_request&);
 
-    http_request* dhr;
+    http_request* dhr = 0x0;
     std::shared_ptr<http_response> dhrs;
-    bool second;
-    bool has_body;
+    bool second = false;
+    bool has_body = false;
 
-    modded_request():
-        pp(0x0),
-        complete_uri(0x0),
-        standardized_url(0x0),
-        ws(0x0),
-        dhr(0x0),
-        second(false),
-        has_body(false)
-    {
-    }
+    modded_request() = default;
 
-    modded_request(const modded_request& b):
-        pp(b.pp),
-        complete_uri(b.complete_uri),
-        standardized_url(b.standardized_url),
-        ws(b.ws),
-        dhr(b.dhr),
-        second(b.second),
-        has_body(b.has_body)
-    {
-    }
+    modded_request(const modded_request& b) = default;
+    modded_request(modded_request&& b) = default;
 
-    modded_request(modded_request&& b):
-        pp(std::move(b.pp)),
-        complete_uri(std::move(b.complete_uri)),
-        standardized_url(std::move(b.standardized_url)),
-        ws(std::move(b.ws)),
-        dhr(std::move(b.dhr)),
-        second(b.second),
-        has_body(b.has_body)
-    {
-    }
-
-    modded_request& operator=(const modded_request& b)
-    {
-        if (this == &b) return *this;
-
-        this->pp = b.pp;
-        this->complete_uri = b.complete_uri;
-        this->standardized_url = b.standardized_url;
-        this->ws = b.ws;
-        this->dhr = b.dhr;
-        this->second = b.second;
-        this->has_body = b.has_body;
-
-        return *this;
-    }
-
-    modded_request& operator=(modded_request&& b)
-    {
-        if (this == &b) return *this;
-
-        this->pp = std::move(b.pp);
-        this->complete_uri = std::move(b.complete_uri);
-        this->standardized_url = std::move(b.standardized_url);
-        this->ws = std::move(b.ws);
-        this->dhr = std::move(b.dhr);
-        this->second = b.second;
-        this->has_body = b.has_body;
-
-        return *this;
-    }
+    modded_request& operator=(const modded_request& b) = default;
+    modded_request& operator=(modded_request&& b) = default;
 
     ~modded_request()
     {

--- a/src/httpserver/digest_auth_fail_response.hpp
+++ b/src/httpserver/digest_auth_fail_response.hpp
@@ -33,13 +33,7 @@ namespace httpserver
 class digest_auth_fail_response : public string_response
 {
     public:
-        digest_auth_fail_response():
-            string_response(),
-            realm(""),
-            opaque(""),
-            reload_nonce(false)
-        {
-        }
+        digest_auth_fail_response() = default;
 
         digest_auth_fail_response(
                 const std::string& content,
@@ -56,56 +50,19 @@ class digest_auth_fail_response : public string_response
         {
         }
 
-        digest_auth_fail_response(const digest_auth_fail_response& other):
-            string_response(other),
-            realm(other.realm),
-            opaque(other.opaque),
-            reload_nonce(other.reload_nonce)
-        {
-        }
+        digest_auth_fail_response(const digest_auth_fail_response& other) = default;
+        digest_auth_fail_response(digest_auth_fail_response&& other) noexcept = default;
+        digest_auth_fail_response& operator=(const digest_auth_fail_response& b) = default;
+        digest_auth_fail_response& operator=(digest_auth_fail_response&& b) noexcept = default;
 
-        digest_auth_fail_response(digest_auth_fail_response&& other) noexcept:
-            string_response(std::move(other)),
-            realm(std::move(other.realm)),
-            opaque(std::move(other.opaque)),
-            reload_nonce(other.reload_nonce)
-        {
-        }
-
-        digest_auth_fail_response& operator=(const digest_auth_fail_response& b)
-        {
-            if (this == &b) return *this;
-
-            (string_response&) (*this) = b;
-            this->realm = b.realm;
-            this->opaque = b.opaque;
-            this->reload_nonce = b.reload_nonce;
-
-            return *this;
-        }
-
-        digest_auth_fail_response& operator=(digest_auth_fail_response&& b)
-        {
-            if (this == &b) return *this;
-
-            (string_response&) (*this) = std::move(b);
-            this->realm = std::move(b.realm);
-            this->opaque = std::move(b.opaque);
-            this->reload_nonce = b.reload_nonce;
-
-            return *this;
-        }
-
-        ~digest_auth_fail_response()
-        {
-        }
+        ~digest_auth_fail_response() = default;
 
         int enqueue_response(MHD_Connection* connection, MHD_Response* response);
 
     private:
-        std::string realm;
-        std::string opaque;
-        bool reload_nonce;
+        std::string realm = "";
+        std::string opaque = "";
+        bool reload_nonce = false;
 };
 
 }

--- a/src/httpserver/digest_auth_fail_response.hpp
+++ b/src/httpserver/digest_auth_fail_response.hpp
@@ -53,7 +53,7 @@ class digest_auth_fail_response : public string_response
         digest_auth_fail_response(const digest_auth_fail_response& other) = default;
         digest_auth_fail_response(digest_auth_fail_response&& other) noexcept = default;
         digest_auth_fail_response& operator=(const digest_auth_fail_response& b) = default;
-        digest_auth_fail_response& operator=(digest_auth_fail_response&& b) noexcept = default;
+        digest_auth_fail_response& operator=(digest_auth_fail_response&& b) = default;
 
         ~digest_auth_fail_response() = default;
 

--- a/src/httpserver/file_response.hpp
+++ b/src/httpserver/file_response.hpp
@@ -33,11 +33,7 @@ namespace httpserver
 class file_response : public http_response
 {
     public:
-        file_response():
-            http_response(),
-            filename("")
-        {
-        }
+        file_response() = default;
 
         explicit file_response(
                 const std::string& filename,
@@ -49,46 +45,18 @@ class file_response : public http_response
         {
         }
 
-        file_response(const file_response& other):
-            http_response(other),
-            filename(other.filename)
-        {
-        }
+        file_response(const file_response& other) = default;
+        file_response(file_response&& other) noexcept = default;
 
-        file_response(file_response&& other) noexcept:
-            http_response(std::move(other)),
-            filename(std::move(other.filename))
-        {
-        }
+        file_response& operator=(const file_response& b) = default;
+        file_response& operator=(file_response&& b) noexcept = default;
 
-        file_response& operator=(const file_response& b)
-        {
-            if (this == &b) return *this;
-
-            (http_response&) (*this) = b;
-            this->filename = b.filename;
-
-            return *this;
-        }
-
-        file_response& operator=(file_response&& b)
-        {
-            if (this == &b) return *this;
-
-            (http_response&) (*this) = std::move(b);
-            this->filename = std::move(b.filename);
-
-            return *this;
-        }
-
-        ~file_response()
-        {
-        }
+        ~file_response() = default;
 
         MHD_Response* get_raw_response();
 
     private:
-        std::string filename;
+        std::string filename = "";
 };
 
 }

--- a/src/httpserver/file_response.hpp
+++ b/src/httpserver/file_response.hpp
@@ -49,7 +49,7 @@ class file_response : public http_response
         file_response(file_response&& other) noexcept = default;
 
         file_response& operator=(const file_response& b) = default;
-        file_response& operator=(file_response&& b) noexcept = default;
+        file_response& operator=(file_response&& b) = default;
 
         ~file_response() = default;
 

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -25,6 +25,7 @@
 #ifndef _HTTP_REQUEST_HPP_
 #define _HTTP_REQUEST_HPP_
 
+#include <limits>
 #include <map>
 #include <vector>
 #include <string>
@@ -216,17 +217,9 @@ class http_request
         /**
          * Default constructor of the class. It is a specific responsibility of apis to initialize this type of objects.
         **/
-        http_request():
-            content(""),
-            content_size_limit(static_cast<size_t>(-1)),
-            underlying_connection(0x0),
-            unescaper(0x0)
-        {
-        }
+        http_request() = default;
 
         http_request(MHD_Connection* underlying_connection, unescaper_ptr unescaper):
-            content(""),
-            content_size_limit(static_cast<size_t>(-1)),
             underlying_connection(underlying_connection),
             unescaper(unescaper)
         {
@@ -236,69 +229,22 @@ class http_request
          * Copy constructor.
          * @param b http_request b to copy attributes from.
         **/
-        http_request(const http_request& b):
-            path(b.path),
-            method(b.method),
-            args(b.args),
-            content(b.content),
-            content_size_limit(b.content_size_limit),
-            version(b.version),
-            underlying_connection(b.underlying_connection),
-            unescaper(b.unescaper)
-        {
-        }
+        http_request(const http_request& b) = default;
+        http_request(http_request&& b) noexcept = default;
 
-        http_request(http_request&& b) noexcept:
-            path(std::move(b.path)),
-            method(std::move(b.method)),
-            args(std::move(b.args)),
-            content(std::move(b.content)),
-            content_size_limit(b.content_size_limit),
-            version(std::move(b.version)),
-            underlying_connection(std::move(b.underlying_connection))
-        {
-        }
-
-        http_request& operator=(const http_request& b)
-        {
-            if (this == &b) return *this;
-
-            this->path = b.path;
-            this->method = b.method;
-            this->args = b.args;
-            this->content = b.content;
-            this->content_size_limit = b.content_size_limit;
-            this->version = b.version;
-            this->underlying_connection = b.underlying_connection;
-
-            return *this;
-        }
-
-        http_request& operator=(http_request&& b)
-        {
-            if (this == &b) return *this;
-
-            this->path = std::move(b.path);
-            this->method = std::move(b.method);
-            this->args = std::move(b.args);
-            this->content = std::move(b.content);
-            this->content_size_limit = b.content_size_limit;
-            this->version = std::move(b.version);
-            this->underlying_connection = std::move(b.underlying_connection);
-
-            return *this;
-        }
+        http_request& operator=(const http_request& b) = default;
+        http_request& operator=(http_request&& b) noexcept = default;
 
         std::string path;
         std::string method;
         std::map<std::string, std::string, http::arg_comparator> args;
-        std::string content;
-        size_t content_size_limit;
+        std::string content = "";
+        size_t content_size_limit = std::numeric_limits<size_t>::max();
         std::string version;
 
-        struct MHD_Connection* underlying_connection;
+        struct MHD_Connection* underlying_connection = nullptr;
 
-        unescaper_ptr unescaper;
+        unescaper_ptr unescaper = nullptr;
 
         static int build_request_header(void *cls, enum MHD_ValueKind kind,
                 const char *key, const char *value

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -233,7 +233,7 @@ class http_request
         http_request(http_request&& b) noexcept = default;
 
         http_request& operator=(const http_request& b) = default;
-        http_request& operator=(http_request&& b) noexcept = default;
+        http_request& operator=(http_request&& b) = default;
 
         std::string path;
         std::string method;

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -25,7 +25,6 @@
 #ifndef _HTTP_REQUEST_HPP_
 #define _HTTP_REQUEST_HPP_
 
-#include <limits>
 #include <map>
 #include <vector>
 #include <string>
@@ -239,12 +238,12 @@ class http_request
         std::string method;
         std::map<std::string, std::string, http::arg_comparator> args;
         std::string content = "";
-        size_t content_size_limit = std::numeric_limits<size_t>::max();
+        size_t content_size_limit = static_cast<size_t>(-1);
         std::string version;
 
-        struct MHD_Connection* underlying_connection = nullptr;
+        struct MHD_Connection* underlying_connection = 0x0;
 
-        unescaper_ptr unescaper = nullptr;
+        unescaper_ptr unescaper = 0x0;
 
         static int build_request_header(void *cls, enum MHD_ValueKind kind,
                 const char *key, const char *value

--- a/src/httpserver/http_resource.hpp
+++ b/src/httpserver/http_resource.hpp
@@ -59,10 +59,7 @@ class http_resource
         /**
          * Class destructor
         **/
-        virtual ~http_resource()
-        {
-            allowed_methods.clear();
-        }
+        virtual ~http_resource() = default;
 
         /**
          * Method used to answer to a generic request
@@ -219,25 +216,10 @@ class http_resource
         /**
          * Copy constructor
         **/
-        http_resource(const http_resource& b) : allowed_methods(b.allowed_methods) { }
-
-        http_resource(http_resource&& b) noexcept: allowed_methods(std::move(b.allowed_methods)) { }
-
-        http_resource& operator=(const http_resource& b)
-        {
-            if (this == &b) return *this;
-
-            allowed_methods = b.allowed_methods;
-            return (*this);
-        }
-
-        http_resource& operator=(http_resource&& b)
-        {
-            if (this == &b) return *this;
-
-            allowed_methods = std::move(b.allowed_methods);
-            return (*this);
-        }
+        http_resource(const http_resource& b) = default;
+        http_resource(http_resource&& b) noexcept = default;
+        http_resource& operator=(const http_resource& b) = default;
+        http_resource& operator=(http_resource&& b) noexcept = default;
 
     private:
         friend class webserver;
@@ -245,5 +227,5 @@ class http_resource
         std::map<std::string, bool> allowed_methods;
 };
 
-};
+}
 #endif

--- a/src/httpserver/http_resource.hpp
+++ b/src/httpserver/http_resource.hpp
@@ -219,7 +219,7 @@ class http_resource
         http_resource(const http_resource& b) = default;
         http_resource(http_resource&& b) noexcept = default;
         http_resource& operator=(const http_resource& b) = default;
-        http_resource& operator=(http_resource&& b) noexcept = default;
+        http_resource& operator=(http_resource&& b) = default;
 
     private:
         friend class webserver;

--- a/src/httpserver/http_response.hpp
+++ b/src/httpserver/http_response.hpp
@@ -150,7 +150,7 @@ class http_response
         std::map<std::string, std::string, http::header_comparator> footers;
         std::map<std::string, std::string, http::header_comparator> cookies;
 
-      	friend std::ostream &operator<< (std::ostream &os, const http_response &r);
+    	friend std::ostream &operator<< (std::ostream &os, const http_response &r);
 };
 
 std::ostream &operator<< (std::ostream &os, const http_response &r);

--- a/src/httpserver/http_response.hpp
+++ b/src/httpserver/http_response.hpp
@@ -45,10 +45,7 @@ namespace httpserver
 class http_response
 {
     public:
-        http_response():
-            response_code(-1)
-        {
-        }
+        http_response() = default;
 
         explicit http_response(int response_code, const std::string& content_type):
             response_code(response_code)
@@ -60,49 +57,13 @@ class http_response
          * Copy constructor
          * @param b The http_response object to copy attributes value from.
         **/
-        http_response(const http_response& b):
-            response_code(b.response_code),
-            headers(b.headers),
-            footers(b.footers),
-            cookies(b.cookies)
-        {
-        }
+        http_response(const http_response& b) = default;
+        http_response(http_response&& b) noexcept = default;
 
-        http_response(http_response&& other) noexcept:
-            response_code(other.response_code),
-            headers(std::move(other.headers)),
-            footers(std::move(other.footers)),
-            cookies(std::move(other.cookies))
-        {
-        }
+        http_response& operator=(const http_response& b) = default;
+        http_response& operator=(http_response&& b) noexcept = default;
 
-        http_response& operator=(const http_response& b)
-        {
-            if (this == &b) return *this;
-
-            this->response_code = b.response_code;
-            this->headers = b.headers;
-            this->footers = b.footers;
-            this->cookies = b.cookies;
-
-            return *this;
-        }
-
-        http_response& operator=(http_response&& b)
-        {
-            if (this == &b) return *this;
-
-            this->response_code = b.response_code;
-            this->headers = std::move(b.headers);
-            this->footers = std::move(b.footers);
-            this->cookies = std::move(b.cookies);
-
-            return *this;
-        }
-
-        virtual ~http_response()
-        {
-        }
+        virtual ~http_response() = default;
 
         /**
          * Method used to get a specified header defined for the response
@@ -183,14 +144,13 @@ class http_response
         virtual int enqueue_response(MHD_Connection* connection, MHD_Response* response);
 
     protected:
-        std::string content;
-        int response_code;
+        int response_code = -1;
 
         std::map<std::string, std::string, http::header_comparator> headers;
         std::map<std::string, std::string, http::header_comparator> footers;
         std::map<std::string, std::string, http::header_comparator> cookies;
 
-    	friend std::ostream &operator<< (std::ostream &os, const http_response &r);
+      	friend std::ostream &operator<< (std::ostream &os, const http_response &r);
 };
 
 std::ostream &operator<< (std::ostream &os, const http_response &r);

--- a/src/httpserver/string_response.hpp
+++ b/src/httpserver/string_response.hpp
@@ -49,7 +49,7 @@ class string_response : public http_response
         string_response(string_response&& other) noexcept = default;
 
         string_response& operator=(const string_response& b) = default;
-        string_response& operator=(string_response&& b) noexcept = default;
+        string_response& operator=(string_response&& b) = default;
 
         ~string_response() = default;
 

--- a/src/httpserver/string_response.hpp
+++ b/src/httpserver/string_response.hpp
@@ -33,11 +33,7 @@ namespace httpserver
 class string_response : public http_response
 {
     public:
-        string_response():
-            http_response(),
-            content("")
-        {
-        }
+        string_response() = default;
 
         explicit string_response(
                 const std::string& content,
@@ -49,46 +45,18 @@ class string_response : public http_response
         {
         }
 
-        string_response(const string_response& other):
-            http_response(other),
-            content(other.content)
-        {
-        }
+        string_response(const string_response& other) = default;
+        string_response(string_response&& other) noexcept = default;
 
-        string_response(string_response&& other) noexcept:
-            http_response(std::move(other)),
-            content(std::move(other.content))
-        {
-        }
+        string_response& operator=(const string_response& b) = default;
+        string_response& operator=(string_response&& b) noexcept = default;
 
-        string_response& operator=(const string_response& b)
-        {
-            if (this == &b) return *this;
-
-            (http_response&) (*this) = b;
-            this->content = b.content;
-
-            return *this;
-        }
-
-        string_response& operator=(string_response&& b)
-        {
-            if (this == &b) return *this;
-
-            (http_response&) (*this) = std::move(b);
-            this->content = std::move(b.content);
-
-            return *this;
-        }
-
-        ~string_response()
-        {
-        }
+        ~string_response() = default;
 
         MHD_Response* get_raw_response();
 
     private:
-        std::string content;
+        std::string content = "";
 };
 
 }


### PR DESCRIPTION
### Identify the Bug
etr/libhttpserver#177 (General code style issues)

### Description of the Change
Use `=default` for constructors and `operator=` where possible.

For default construction, this moves the default values to a default member initializer:
https://en.cppreference.com/w/cpp/language/data_members#Member_initialization

This significantly reduce the size of code in a number of places. It also avoids the need to ensure that the list of copied/moved fields matches the list of existing fields (in some case it did not).

### Possible Drawbacks
This removes the "effectively unused" protected member http_response::content. If any client code references that, this will break it.

### Verification Process

    ./bootstrap 
    mkdir build
    cd build
    CPPFLAGS=-I${libmicrohttpd_include} LDFLAGS=-L${libmicrohttpd_libs} ../configure
    make

### Release Notes

Use `=default` for constructors and `operator=` where possible.