### PR TITLE
Rename some variable so that all `this->` can be dropped, and do so.

### DIFF
--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -37,9 +37,9 @@ struct arguments_accumulator
     std::map<std::string, std::string, http::arg_comparator>* arguments;
 };
 
-void http_request::set_method(const std::string& method)
+void http_request::set_method(const std::string& method_src)
 {
-    this->method = string_utilities::to_upper_copy(method);
+    method = string_utilities::to_upper_copy(method_src);
 }
 
 bool http_request::check_digest_auth(
@@ -76,7 +76,7 @@ bool http_request::check_digest_auth(
 const std::string http_request::get_connection_value(const std::string& key, enum MHD_ValueKind kind) const
 {
     const char* header_c = MHD_lookup_connection_value(
-        this->underlying_connection,
+        underlying_connection,
         kind,
         key.c_str()
     );
@@ -103,7 +103,7 @@ const std::map<std::string, std::string, http::header_comparator> http_request::
     std::map<std::string, std::string, http::header_comparator> headers;
 
     MHD_get_connection_values(
-        this->underlying_connection,
+        underlying_connection,
         kind,
         &build_request_header,
         (void*) &headers
@@ -144,9 +144,9 @@ const std::map<std::string, std::string, http::header_comparator> http_request::
 
 const std::string http_request::get_arg(const std::string& key) const
 {
-    std::map<std::string, std::string>::const_iterator it = this->args.find(key);
+    std::map<std::string, std::string>::const_iterator it = args.find(key);
 
-    if(it != this->args.end())
+    if(it != args.end())
     {
         return it->second;
     }
@@ -157,14 +157,14 @@ const std::string http_request::get_arg(const std::string& key) const
 const std::map<std::string, std::string, http::arg_comparator> http_request::get_args() const
 {
     std::map<std::string, std::string, http::arg_comparator> arguments;
-    arguments.insert(this->args.begin(), this->args.end());
+    arguments.insert(args.begin(), args.end());
 
     arguments_accumulator aa;
-    aa.unescaper = this->unescaper;
+    aa.unescaper = unescaper;
     aa.arguments = &arguments;
 
     MHD_get_connection_values(
-        this->underlying_connection,
+        underlying_connection,
         MHD_GET_ARGUMENT_KIND,
         &build_request_args,
         (void*) &aa
@@ -178,7 +178,7 @@ const std::string http_request::get_querystring() const
     std::string querystring = "";
 
     MHD_get_connection_values(
-        this->underlying_connection,
+        underlying_connection,
         MHD_GET_ARGUMENT_KIND,
         &build_request_querystring,
         (void*) &querystring

--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -37,9 +37,9 @@ struct arguments_accumulator
     std::map<std::string, std::string, http::arg_comparator>* arguments;
 };
 
-void http_request::set_method(const std::string& method_src)
+void http_request::set_method(const std::string& method)
 {
-    method = string_utilities::to_upper_copy(method_src);
+    this->method = string_utilities::to_upper_copy(method);
 }
 
 bool http_request::check_digest_auth(

--- a/src/http_response.cpp
+++ b/src/http_response.cpp
@@ -70,7 +70,7 @@ int http_response::enqueue_response(MHD_Connection* connection, MHD_Response* re
 
 void http_response::shoutCAST()
 {
-    this->response_code |= http::http_utils::shoutcast_response;
+    response_code |= http::http_utils::shoutcast_response;
 }
 
 std::ostream &operator<< (std::ostream &os, const http_response &r)

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -517,16 +517,16 @@ bool ip_representation::operator <(const ip_representation& b) const
     {
         if (i == 10 || i == 11) continue;
 
-        if (CHECK_BIT(this->mask, i) && CHECK_BIT(b.mask, i))
+        if (CHECK_BIT(mask, i) && CHECK_BIT(b.mask, i))
         {
-            this_score += (16 - i) * this->pieces[i];
+            this_score += (16 - i) * pieces[i];
             b_score += (16 - i) * b.pieces[i];
         }
     }
 
     if (this_score == b_score &&
-       ((this->pieces[10] == 0x00 || this->pieces[10] == 0xFF) && (b.pieces[10] == 0x00 || b.pieces[10] == 0xFF)) &&
-       ((this->pieces[11] == 0x00 || this->pieces[11] == 0xFF) && (b.pieces[11] == 0x00 || b.pieces[11] == 0xFF))
+       ((pieces[10] == 0x00 || pieces[10] == 0xFF) && (b.pieces[10] == 0x00 || b.pieces[10] == 0xFF)) &&
+       ((pieces[11] == 0x00 || pieces[11] == 0xFF) && (b.pieces[11] == 0x00 || b.pieces[11] == 0xFF))
     )
     {
         return false;
@@ -534,9 +534,9 @@ bool ip_representation::operator <(const ip_representation& b) const
 
     for (int i = 10; i < 12; i++)
     {
-        if (CHECK_BIT(this->mask, i) && CHECK_BIT(b.mask, i))
+        if (CHECK_BIT(mask, i) && CHECK_BIT(b.mask, i))
         {
-            this_score += (16 - i) * this->pieces[i];
+            this_score += (16 - i) * pieces[i];
             b_score += (16 - i) * b.pieces[i];
         }
     }

--- a/src/httpserver/deferred_response.hpp
+++ b/src/httpserver/deferred_response.hpp
@@ -62,7 +62,7 @@ class deferred_response : public string_response
 
         MHD_Response* get_raw_response()
         {
-            return details::get_raw_response_helper((void*) this, &(this->cb));
+            return details::get_raw_response_helper((void*) this, &cb);
         }
 
     private:

--- a/src/httpserver/details/http_endpoint.hpp
+++ b/src/httpserver/details/http_endpoint.hpp
@@ -85,12 +85,12 @@ class http_endpoint
         **/
         const std::string& get_url_complete() const
         {
-            return this->url_complete;
+            return url_complete;
         }
 
         const std::string& get_url_normalized() const
         {
-            return this->url_normalized;
+            return url_normalized;
         }
 
         /**
@@ -99,7 +99,7 @@ class http_endpoint
         **/
         const std::vector<std::string>& get_url_pars() const
         {
-            return this->url_pars;
+            return url_pars;
         }
 
         /**
@@ -108,7 +108,7 @@ class http_endpoint
         **/
         const std::vector<std::string>& get_url_pieces() const
         {
-            return this->url_pieces;
+            return url_pieces;
         }
 
         /**
@@ -117,17 +117,17 @@ class http_endpoint
         **/
         const std::vector<int>& get_chunk_positions() const
         {
-            return this->chunk_positions;
+            return chunk_positions;
         }
 
         const bool is_family_url() const
         {
-            return this->family_url;
+            return family_url;
         }
 
         const bool is_regex_compiled() const
         {
-            return this->reg_compiled;
+            return reg_compiled;
         }
 
         /**

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -282,18 +282,18 @@ class http_request
          * Method used to set the content of the request
          * @param content The content to set.
         **/
-        void set_content(const std::string& content_src)
+        void set_content(const std::string& content)
         {
-            content = content_src.substr(0,content_size_limit);
+            this->content = content.substr(0,content_size_limit);
         }
 
         /**
          * Method used to set the maximum size of the content
          * @param content_size_limit The limit on the maximum size of the content and arg's.
         **/
-        void set_content_size_limit(size_t content_size_limit_src)
+        void set_content_size_limit(size_t content_size_limit)
         {
-            content_size_limit = content_size_limit_src;
+            this->content_size_limit = content_size_limit;
         }
 
         /**
@@ -301,12 +301,12 @@ class http_request
          * @param content The content to append.
          * @param size The size of the data to append.
         **/
-        void grow_content(const char* content_ptr, size_t size)
+        void grow_content(const char* content, size_t size)
         {
-            content.append(content_ptr, size);
-            if (content.size() > content_size_limit)
+            this->content.append(content, size);
+            if (this->content.size() > content_size_limit)
             {
-                content.resize (content_size_limit);
+                this->content.resize (content_size_limit);
             }
         }
 
@@ -314,9 +314,9 @@ class http_request
          * Method used to set the path requested.
          * @param path The path searched by the request.
         **/
-        void set_path(const std::string& path_src)
+        void set_path(const std::string& path)
         {
-            path = path_src;
+            this->path = path;
         }
 
         /**
@@ -329,20 +329,20 @@ class http_request
          * Method used to set the request http version (ie http 1.1)
          * @param version The version to set in form of string
         **/
-        void set_version(const std::string& version_src)
+        void set_version(const std::string& version)
         {
-            version = version_src;
+            this->version = version;
         }
 
         /**
          * Method used to set all arguments of the request.
          * @param args The args key-value map to set for the request.
         **/
-        void set_args(const std::map<std::string, std::string>& args_src)
+        void set_args(const std::map<std::string, std::string>& args)
         {
             std::map<std::string, std::string>::const_iterator it;
-            for(it = args_src.begin(); it != args_src.end(); ++it)
-                args[it->first] = it->second.substr(0,content_size_limit);
+            for(it = args.begin(); it != args.end(); ++it)
+                this->args[it->first] = it->second.substr(0,content_size_limit);
         }
 
         const std::string get_connection_value(const std::string& key, enum MHD_ValueKind kind) const;

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -76,7 +76,7 @@ class http_request
         **/
         const std::string& get_path() const
         {
-            return this->path;
+            return path;
         }
 
         /**
@@ -85,7 +85,7 @@ class http_request
         **/
         const std::vector<std::string> get_path_pieces() const
         {
-            return http::http_utils::tokenize_url(this->path);
+            return http::http_utils::tokenize_url(path);
         }
 
         /**
@@ -95,7 +95,7 @@ class http_request
         **/
         const std::string get_path_piece(int index) const
         {
-            std::vector<std::string> post_path = this->get_path_pieces();
+            std::vector<std::string> post_path = get_path_pieces();
             if(((int)(post_path.size())) > index)
                 return post_path[index];
             return EMPTY;
@@ -107,7 +107,7 @@ class http_request
         **/
         const std::string& get_method() const
         {
-            return this->method;
+            return method;
         }
 
         /**
@@ -167,7 +167,7 @@ class http_request
         **/
         const std::string& get_content() const
         {
-            return this->content;
+            return content;
         }
 
         /**
@@ -190,7 +190,7 @@ class http_request
         **/
         const std::string& get_version() const
         {
-            return this->version;
+            return version;
         }
 
         /**
@@ -264,7 +264,7 @@ class http_request
         **/
         void set_arg(const std::string& key, const std::string& value)
         {
-            this->args[key] = value.substr(0,content_size_limit);
+            args[key] = value.substr(0,content_size_limit);
         }
 
         /**
@@ -275,26 +275,25 @@ class http_request
         **/
         void set_arg(const char* key, const char* value, size_t size)
         {
-            this->args[key] = std::string(value,
-                                          std::min(size, content_size_limit));
+            args[key] = std::string(value, std::min(size, content_size_limit));
         }
 
         /**
          * Method used to set the content of the request
          * @param content The content to set.
         **/
-        void set_content(const std::string& content)
+        void set_content(const std::string& content_src)
         {
-            this->content = content.substr(0,content_size_limit);
+            content = content_src.substr(0,content_size_limit);
         }
 
         /**
          * Method used to set the maximum size of the content
          * @param content_size_limit The limit on the maximum size of the content and arg's.
         **/
-        void set_content_size_limit(size_t content_size_limit)
+        void set_content_size_limit(size_t content_size_limit_src)
         {
-            this->content_size_limit = content_size_limit;
+            content_size_limit = content_size_limit_src;
         }
 
         /**
@@ -302,12 +301,12 @@ class http_request
          * @param content The content to append.
          * @param size The size of the data to append.
         **/
-        void grow_content(const char* content, size_t size)
+        void grow_content(const char* content_ptr, size_t size)
         {
-            this->content.append(content, size);
-            if (this->content.size() > content_size_limit)
+            content.append(content_ptr, size);
+            if (content.size() > content_size_limit)
             {
-                this->content.resize (content_size_limit);
+                content.resize (content_size_limit);
             }
         }
 
@@ -315,9 +314,9 @@ class http_request
          * Method used to set the path requested.
          * @param path The path searched by the request.
         **/
-        void set_path(const std::string& path)
+        void set_path(const std::string& path_src)
         {
-            this->path = path;
+            path = path_src;
         }
 
         /**
@@ -330,20 +329,20 @@ class http_request
          * Method used to set the request http version (ie http 1.1)
          * @param version The version to set in form of string
         **/
-        void set_version(const std::string& version)
+        void set_version(const std::string& version_src)
         {
-            this->version = version;
+            version = version_src;
         }
 
         /**
          * Method used to set all arguments of the request.
          * @param args The args key-value map to set for the request.
         **/
-        void set_args(const std::map<std::string, std::string>& args)
+        void set_args(const std::map<std::string, std::string>& args_src)
         {
             std::map<std::string, std::string>::const_iterator it;
-            for(it = args.begin(); it != args.end(); ++it)
-                this->args[it->first] = it->second.substr(0,content_size_limit);
+            for(it = args_src.begin(); it != args_src.end(); ++it)
+                args[it->first] = it->second.substr(0,content_size_limit);
         }
 
         const std::string get_connection_value(const std::string& key, enum MHD_ValueKind kind) const;

--- a/src/httpserver/http_resource.hpp
+++ b/src/httpserver/http_resource.hpp
@@ -158,9 +158,9 @@ class http_resource
         **/
         void set_allowing(const std::string& method, bool allowed)
         {
-            if(this->allowed_methods.count(method))
+            if(allowed_methods.count(method))
             {
-                this->allowed_methods[method] = allowed;
+                allowed_methods[method] = allowed;
             }
         }
         /**
@@ -169,8 +169,8 @@ class http_resource
         void allow_all()
         {
             std::map<std::string,bool>::iterator it;
-            for ( it=this->allowed_methods.begin() ; it != this->allowed_methods.end(); ++it )
-                this->allowed_methods[(*it).first] = true;
+            for ( it=allowed_methods.begin() ; it != allowed_methods.end(); ++it )
+                allowed_methods[(*it).first] = true;
         }
         /**
          * Method used to implicitly disallow all methods
@@ -178,8 +178,8 @@ class http_resource
         void disallow_all()
         {
             std::map<std::string,bool>::iterator it;
-            for ( it=this->allowed_methods.begin() ; it != this->allowed_methods.end(); ++it )
-                this->allowed_methods[(*it).first] = false;
+            for ( it=allowed_methods.begin() ; it != allowed_methods.end(); ++it )
+                allowed_methods[(*it).first] = false;
         }
         /**
          * Method used to discover if an http method is allowed or not for this resource
@@ -188,9 +188,9 @@ class http_resource
         **/
         bool is_allowed(const std::string& method)
         {
-            if(this->allowed_methods.count(method))
+            if(allowed_methods.count(method))
             {
-                return this->allowed_methods[method];
+                return allowed_methods[method];
             }
             else
             {

--- a/src/httpserver/http_response.hpp
+++ b/src/httpserver/http_response.hpp
@@ -50,7 +50,7 @@ class http_response
         explicit http_response(int response_code, const std::string& content_type):
             response_code(response_code)
         {
-            this->headers[http::http_utils::http_header_content_type] = content_type;
+            headers[http::http_utils::http_header_content_type] = content_type;
         }
 
         /**
@@ -72,7 +72,7 @@ class http_response
         **/
         const std::string& get_header(const std::string& key)
         {
-            return this->headers[key];
+            return headers[key];
         }
 
         /**
@@ -82,12 +82,12 @@ class http_response
         **/
         const std::string& get_footer(const std::string& key)
         {
-            return this->footers[key];
+            return footers[key];
         }
 
         const std::string& get_cookie(const std::string& key)
         {
-            return this->cookies[key];
+            return cookies[key];
         }
 
         /**
@@ -96,7 +96,7 @@ class http_response
         **/
         const std::map<std::string, std::string, http::header_comparator>& get_headers() const
         {
-            return this->headers;
+            return headers;
         }
 
         /**
@@ -105,12 +105,12 @@ class http_response
         **/
         const std::map<std::string, std::string, http::header_comparator>& get_footers() const
         {
-            return this->footers;
+            return footers;
         }
 
         const std::map<std::string, std::string, http::header_comparator>& get_cookies() const
         {
-            return this->cookies;
+            return cookies;
         }
 
         /**
@@ -119,7 +119,7 @@ class http_response
         **/
         int get_response_code() const
         {
-            return this->response_code;
+            return response_code;
         }
 
         void with_header(const std::string& key, const std::string& value)

--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -110,22 +110,22 @@ class webserver
 
         log_access_ptr get_access_logger() const
         {
-            return this->log_access;
+            return log_access;
         }
 
         log_error_ptr get_error_logger() const
         {
-            return this->log_error;
+            return log_error;
         }
 
         validator_ptr get_request_validator() const
         {
-            return this->validator;
+            return validator;
         }
 
         unescaper_ptr get_unescaper() const
         {
-            return this->unescaper;
+            return unescaper;
         }
 
         /**

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -245,9 +245,9 @@ class error_resource : public http_resource
 class print_request_resource : public http_resource
 {
     public:
-        print_request_resource(std::stringstream* ss_src)
+        print_request_resource(std::stringstream* ss)
         {
-            ss = ss_src;
+            this->ss = ss;
         }
 
         const shared_ptr<http_response> render_GET(const http_request& req)
@@ -263,9 +263,9 @@ class print_request_resource : public http_resource
 class print_response_resource : public http_resource
 {
     public:
-        print_response_resource(std::stringstream* ss_src)
+        print_response_resource(std::stringstream* ss)
         {
-            ss = ss_src;
+            this->ss = ss;
         }
 
         const shared_ptr<http_response> render_GET(const http_request& req)

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -245,9 +245,9 @@ class error_resource : public http_resource
 class print_request_resource : public http_resource
 {
     public:
-        print_request_resource(std::stringstream* ss)
+        print_request_resource(std::stringstream* ss_src)
         {
-            this->ss = ss;
+            ss = ss_src;
         }
 
         const shared_ptr<http_response> render_GET(const http_request& req)
@@ -263,9 +263,9 @@ class print_request_resource : public http_resource
 class print_response_resource : public http_resource
 {
     public:
-        print_response_resource(std::stringstream* ss)
+        print_response_resource(std::stringstream* ss_src)
         {
-            this->ss = ss;
+            ss = ss_src;
         }
 
         const shared_ptr<http_response> render_GET(const http_request& req)


### PR DESCRIPTION
### Identify the Bug
etr/libhttpserver#177 (General code style issues)

### Description of the Change

Rename some variable so that all `this->` can be dropped, and do so.

`this->` is almost always redundant.  

Side Note: the cases where this required changing the name of local variable to not conflict with member variable is the reason that many style guides (e.g. https://google.github.io/styleguide/cppguide.html#Variable_Names) require different forms for those types of variables. It may be worth renaming all private member variables at some point.

### Alternate Designs

n/a

### Possible Drawbacks

none really.

### Verification Process

Normal build process. CI build to follow

### Release Notes

- Code cleanup relating to `this->`.