### PR TITLE
Move http_response class members to private.

### DIFF
--- a/src/httpserver/http_response.hpp
+++ b/src/httpserver/http_response.hpp
@@ -143,13 +143,14 @@ class http_response
         virtual void decorate_response(MHD_Response* response);
         virtual int enqueue_response(MHD_Connection* connection, MHD_Response* response);
 
-    protected:
+    private:
         int response_code = -1;
 
         std::map<std::string, std::string, http::header_comparator> headers;
         std::map<std::string, std::string, http::header_comparator> footers;
         std::map<std::string, std::string, http::header_comparator> cookies;
 
+    protected:
     	friend std::ostream &operator<< (std::ostream &os, const http_response &r);
 };
 


### PR DESCRIPTION
### Identify the Bug

As by discussion in this PR: https://github.com/etr/libhttpserver/pull/180 . The http_response object contains protected members for no apparent reason. This, besides making the internals of the class visible from the outside, impedes improvement to the code.

### Description of the Change

Move the members to the private section.
There wasn't really a good reason for them to be protected in the first place. It was just a residual from before the Jan 2019 cleanup to the http_response chain of dependencies.

### Possible Drawbacks

If external code has taken a dependency on these fields, this change would result in a failure for such code. 

### Verification Process

unit/integration testing. The change will also run through Travis before being pushed.

### Release Notes

All protected class members variables in http_response have been changed to be private.
