### PR TITLE
Sort include (using the Google C++ style pattern). Also add some more…

### DIFF
--- a/examples/benchmark_nodelay.cpp
+++ b/examples/benchmark_nodelay.cpp
@@ -1,6 +1,7 @@
-#include <httpserver.hpp>
 #include <cstdlib>
 #include <memory>
+
+#include <httpserver.hpp>
 
 #define PATH "/plaintext"
 #define BODY "Hello, World!"

--- a/examples/benchmark_select.cpp
+++ b/examples/benchmark_select.cpp
@@ -1,6 +1,7 @@
-#include <httpserver.hpp>
 #include <cstdlib>
 #include <memory>
+
+#include <httpserver.hpp>
 
 #define PATH "/plaintext"
 #define BODY "Hello, World!"

--- a/examples/benchmark_threads.cpp
+++ b/examples/benchmark_threads.cpp
@@ -1,6 +1,7 @@
-#include <httpserver.hpp>
 #include <cstdlib>
 #include <memory>
+
+#include <httpserver.hpp>
 
 #define PATH "/plaintext"
 #define BODY "Hello, World!"

--- a/examples/custom_access_log.cpp
+++ b/examples/custom_access_log.cpp
@@ -18,8 +18,9 @@
      USA
 */
 
-#include <httpserver.hpp>
 #include <iostream>
+
+#include <httpserver.hpp>
 
 using namespace httpserver;
 

--- a/examples/deferred_with_accumulator.cpp
+++ b/examples/deferred_with_accumulator.cpp
@@ -18,9 +18,10 @@
      USA
 */
 
+#include <atomic>
 #include <chrono>
 #include <thread>
-#include <atomic>
+
 #include <httpserver.hpp>
 
 using namespace httpserver;

--- a/examples/hello_world.cpp
+++ b/examples/hello_world.cpp
@@ -18,8 +18,9 @@
      USA
 */
 
-#include <httpserver.hpp>
 #include <iostream>
+
+#include <httpserver.hpp>
 
 using namespace httpserver;
 

--- a/examples/service.cpp
+++ b/examples/service.cpp
@@ -18,10 +18,12 @@
      USA
 */
 
-#include <httpserver.hpp>
-#include <iostream>
 #include <unistd.h>
+
 #include <cstdio>
+#include <iostream>
+
+#include <httpserver.hpp>
 
 using namespace httpserver;
 

--- a/src/details/http_endpoint.cpp
+++ b/src/details/http_endpoint.cpp
@@ -19,6 +19,7 @@
 */
 
 #include "httpserver/details/http_endpoint.hpp"
+
 #include "httpserver/http_utils.hpp"
 #include "httpserver/string_utilities.hpp"
 

--- a/src/file_response.cpp
+++ b/src/file_response.cpp
@@ -18,8 +18,9 @@
      USA
 */
 
-#include <fcntl.h>
 #include "httpserver/file_response.hpp"
+
+#include <fcntl.h>
 
 using namespace std;
 

--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -19,10 +19,12 @@
 
 */
 
-#include "httpserver/http_utils.hpp"
 #include "httpserver/http_request.hpp"
-#include "httpserver/string_utilities.hpp"
+
 #include <iostream>
+
+#include "httpserver/http_utils.hpp"
+#include "httpserver/string_utilities.hpp"
 
 using namespace std;
 

--- a/src/http_resource.cpp
+++ b/src/http_resource.cpp
@@ -18,15 +18,16 @@
 
 */
 
+#include "httpserver/http_resource.hpp"
+
 #include <stdlib.h>
 
-#include "httpserver/http_resource.hpp"
-#include "httpserver/http_utils.hpp"
 #include "httpserver/http_request.hpp"
 #include "httpserver/http_response.hpp"
-#include "httpserver/webserver.hpp"
-#include "httpserver/string_utilities.hpp"
+#include "httpserver/http_utils.hpp"
 #include "httpserver/string_response.hpp"
+#include "httpserver/string_utilities.hpp"
+#include "httpserver/webserver.hpp"
 
 using namespace std;
 

--- a/src/http_response.cpp
+++ b/src/http_response.cpp
@@ -18,15 +18,17 @@
      USA
 */
 
+#include "httpserver/http_response.hpp"
+
+#include <fcntl.h>
+#include <unistd.h>
 #include <cstdio>
 #include <functional>
 #include <iostream>
 #include <sstream>
-#include <fcntl.h>
-#include <unistd.h>
+
 #include "httpserver/http_utils.hpp"
 #include "httpserver/webserver.hpp"
-#include "httpserver/http_response.hpp"
 
 using namespace std;
 

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -18,9 +18,8 @@
      USA
 */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "httpserver/http_utils.hpp"
+
 #if defined(__MINGW32__) || defined(__CYGWIN32__)
 #define _WINDOWS
 #undef _WIN32_WINNT
@@ -32,13 +31,17 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #endif
-#include <sstream>
-#include <iomanip>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
+
 #include "httpserver/string_utilities.hpp"
-#include "httpserver/http_utils.hpp"
 
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))

--- a/src/httpserver.hpp
+++ b/src/httpserver.hpp
@@ -23,17 +23,15 @@
 
 #define _HTTPSERVER_HPP_INSIDE_
 
-#include "httpserver/http_utils.hpp"
+#include "httpserver/basic_auth_fail_response.hpp"
+#include "httpserver/deferred_response.hpp"
+#include "httpserver/digest_auth_fail_response.hpp"
+#include "httpserver/file_response.hpp"
+#include "httpserver/http_request.hpp"
 #include "httpserver/http_resource.hpp"
 #include "httpserver/http_response.hpp"
-
+#include "httpserver/http_utils.hpp"
 #include "httpserver/string_response.hpp"
-#include "httpserver/basic_auth_fail_response.hpp"
-#include "httpserver/digest_auth_fail_response.hpp"
-#include "httpserver/deferred_response.hpp"
-#include "httpserver/file_response.hpp"
-
-#include "httpserver/http_request.hpp"
 #include "httpserver/webserver.hpp"
 
 #endif

--- a/src/httpserver/create_webserver.hpp
+++ b/src/httpserver/create_webserver.hpp
@@ -26,8 +26,9 @@
 #define _CREATE_WEBSERVER_HPP_
 
 #include <stdlib.h>
-#include "httpserver/http_utils.hpp"
+
 #include "httpserver/http_response.hpp"
+#include "httpserver/http_utils.hpp"
 
 #define DEFAULT_WS_TIMEOUT 180
 #define DEFAULT_WS_PORT 9898

--- a/src/httpserver/deferred_response.hpp
+++ b/src/httpserver/deferred_response.hpp
@@ -26,6 +26,7 @@
 #define _DEFERRED_RESPONSE_HPP_
 
 #include <memory>
+
 #include "httpserver/string_response.hpp"
 
 namespace httpserver

--- a/src/httpserver/details/http_endpoint.hpp
+++ b/src/httpserver/details/http_endpoint.hpp
@@ -25,11 +25,11 @@
 #ifndef _HTTP_ENDPOINT_HPP_
 #define _HTTP_ENDPOINT_HPP_
 
-#include <vector>
-#include <utility>
 #include <regex.h>
-#include <string>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace httpserver
 {

--- a/src/httpserver/details/modded_request.hpp
+++ b/src/httpserver/details/modded_request.hpp
@@ -25,6 +25,8 @@
 #ifndef _MODDED_REQUEST_HPP_
 #define _MODDED_REQUEST_HPP_
 
+#include "httpserver/http_request.hpp"
+
 namespace httpserver
 {
 

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -25,11 +25,13 @@
 #ifndef _HTTP_REQUEST_HPP_
 #define _HTTP_REQUEST_HPP_
 
+#include <iosfwd>
 #include <map>
-#include <vector>
 #include <string>
 #include <utility>
-#include <iosfwd>
+#include <vector>
+
+#include "httpserver/http_utils.hpp"
 
 struct MHD_Connection;
 

--- a/src/httpserver/http_resource.hpp
+++ b/src/httpserver/http_resource.hpp
@@ -24,13 +24,13 @@
 
 #ifndef _http_resource_hpp_
 #define _http_resource_hpp_
-#include <map>
-#include <string>
-#include <memory>
 
 #ifdef DEBUG
 #include <iostream>
 #endif
+#include <map>
+#include <memory>
+#include <string>
 
 #include "httpserver/http_response.hpp"
 

--- a/src/httpserver/http_response.hpp
+++ b/src/httpserver/http_response.hpp
@@ -24,11 +24,12 @@
 
 #ifndef _HTTP_RESPONSE_HPP_
 #define _HTTP_RESPONSE_HPP_
-#include <map>
-#include <utility>
-#include <string>
+
 #include <iosfwd>
+#include <map>
 #include <stdint.h>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "httpserver/http_utils.hpp"

--- a/src/httpserver/http_utils.hpp
+++ b/src/httpserver/http_utils.hpp
@@ -25,17 +25,17 @@
 #ifndef _HTTPUTILS_H_
 #define _HTTPUTILS_H_
 
-#include <microhttpd.h>
-#include <string>
-#include <cctype>
-#include <vector>
-#include <map>
-#include <algorithm>
-#include <exception>
-#include <iosfwd>
 #ifdef HAVE_GNUTLS
 #include <gnutls/gnutls.h>
 #endif
+#include <microhttpd.h>
+#include <algorithm>
+#include <cctype>
+#include <exception>
+#include <iosfwd>
+#include <map>
+#include <string>
+#include <vector>
 
 #define DEFAULT_MASK_VALUE 0xFFFF
 

--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -30,23 +30,21 @@
 #define NOT_METHOD_ERROR "Method not Acceptable"
 #define GENERIC_ERROR "Internal Error"
 
+#include <pthread.h>
+#include <stdlib.h>
 #include <cstring>
+#include <deque>
 #include <map>
-#include <vector>
+#include <memory>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <utility>
-#include <stdlib.h>
-#include <memory>
-#include <deque>
-
-#include <pthread.h>
-#include <stdexcept>
+#include <vector>
 
 #include "httpserver/create_webserver.hpp"
-#include "httpserver/http_response.hpp"
-
 #include "httpserver/details/http_endpoint.hpp"
+#include "httpserver/http_response.hpp"
 
 namespace httpserver {
 

--- a/src/string_utilities.cpp
+++ b/src/string_utilities.cpp
@@ -18,16 +18,17 @@
      USA
 */
 
+#include "httpserver/string_utilities.hpp"
+
+#include <regex.h>
 #include <algorithm>
-#include <string>
-#include <istream>
-#include <sstream>
-#include <vector>
 #include <cctype>
 #include <cstdlib>
 #include <cstring>
-#include <regex.h>
-#include "httpserver/string_utilities.hpp"
+#include <istream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace httpserver
 {

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -18,17 +18,7 @@
      USA
 */
 
-#include <stdint.h>
-#include <inttypes.h>
-#include <iostream>
-#include <stdlib.h>
-#include <stdio.h>
-#include <errno.h>
-#include <unistd.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/time.h>
-#include <stdexcept>
+#include "httpserver/webserver.hpp"
 
 #if defined(__MINGW32__) || defined(__CYGWIN32__)
 #include <winsock2.h>
@@ -39,23 +29,32 @@
 #include <netinet/tcp.h>
 #endif
 
-#include <signal.h>
+#include <errno.h>
 #include <fcntl.h>
-#include <algorithm>
-
+#include <inttypes.h>
 #include <microhttpd.h>
+#include <signal.h>
+#include <stdexcept>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <algorithm>
+#include <iostream>
 
 #include "gettext.h"
-#include "httpserver/http_utils.hpp"
+#include "httpserver/create_webserver.hpp"
+#include "httpserver/details/http_endpoint.hpp"
+#include "httpserver/details/modded_request.hpp"
+#include "httpserver/http_request.hpp"
 #include "httpserver/http_resource.hpp"
 #include "httpserver/http_response.hpp"
+#include "httpserver/http_utils.hpp"
 #include "httpserver/string_response.hpp"
-#include "httpserver/http_request.hpp"
-#include "httpserver/details/http_endpoint.hpp"
 #include "httpserver/string_utilities.hpp"
-#include "httpserver/create_webserver.hpp"
-#include "httpserver/webserver.hpp"
-#include "httpserver/details/modded_request.hpp"
 
 #define _REENTRANT 1
 

--- a/test/integ/authentication.cpp
+++ b/test/integ/authentication.cpp
@@ -28,11 +28,12 @@
 #include <arpa/inet.h>
 #endif
 
-#include "littletest.hpp"
 #include <curl/curl.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+
 #include "httpserver.hpp"
+#include "littletest.hpp"
 
 #define MY_OPAQUE "11733b200778ce33060f31c9af70a870ba96ddd4"
 

--- a/test/integ/ban_system.cpp
+++ b/test/integ/ban_system.cpp
@@ -18,12 +18,13 @@
      USA
 */
 
-#include "littletest.hpp"
 #include <curl/curl.h>
-#include <string>
 #include <map>
+#include <string>
+
 #include "httpserver.hpp"
 #include "httpserver/http_utils.hpp"
+#include "littletest.hpp"
 
 using namespace httpserver;
 using namespace std;

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -18,13 +18,14 @@
      USA
 */
 
-#include "littletest.hpp"
 #include <curl/curl.h>
-#include <string>
-#include <sstream>
 #include <map>
-#include "httpserver/string_utilities.hpp"
+#include <sstream>
+#include <string>
+
 #include "httpserver.hpp"
+#include "httpserver/string_utilities.hpp"
+#include "littletest.hpp"
 
 using namespace httpserver;
 using namespace std;

--- a/test/integ/deferred.cpp
+++ b/test/integ/deferred.cpp
@@ -28,13 +28,14 @@
 #include <arpa/inet.h>
 #endif
 
-#include "littletest.hpp"
 #include <curl/curl.h>
 #include <netinet/in.h>
-#include <sys/socket.h>
-#include "httpserver.hpp"
-#include <unistd.h>
 #include <signal.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "httpserver.hpp"
+#include "littletest.hpp"
 
 using namespace std;
 using namespace httpserver;

--- a/test/integ/nodelay.cpp
+++ b/test/integ/nodelay.cpp
@@ -18,11 +18,12 @@
      USA
 */
 
-#include "littletest.hpp"
 #include <curl/curl.h>
-#include <string>
 #include <map>
+#include <string>
+
 #include "httpserver.hpp"
+#include "littletest.hpp"
 
 using namespace httpserver;
 using namespace std;

--- a/test/integ/threaded.cpp
+++ b/test/integ/threaded.cpp
@@ -18,11 +18,12 @@
      USA
 */
 
-#include "littletest.hpp"
 #include <curl/curl.h>
-#include <string>
 #include <map>
+#include <string>
+
 #include "httpserver.hpp"
+#include "littletest.hpp"
 
 using namespace httpserver;
 using namespace std;

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -28,12 +28,13 @@
 #include <arpa/inet.h>
 #endif
 
-#include "littletest.hpp"
 #include <curl/curl.h>
 #include <netinet/in.h>
-#include <sys/socket.h>
-#include "httpserver.hpp"
 #include <pthread.h>
+#include <sys/socket.h>
+
+#include "httpserver.hpp"
+#include "littletest.hpp"
 
 using namespace std;
 using namespace httpserver;

--- a/test/littletest.hpp
+++ b/test/littletest.hpp
@@ -23,11 +23,11 @@
 #ifndef _LITTLETEST_HPP_
 #define _LITTLETEST_HPP_
 
-#include <string>
+#include <sys/time.h>
+#include <algorithm>
 #include <iostream>
 #include <sstream>
-#include <algorithm>
-#include <sys/time.h>
+#include <string>
 #include <vector>
 
 #define LT_VERSION 1.0

--- a/test/unit/http_endpoint_test.cpp
+++ b/test/unit/http_endpoint_test.cpp
@@ -18,8 +18,9 @@
      USA
 */
 
-#include "littletest.hpp"
 #include "httpserver/details/http_endpoint.hpp"
+
+#include "littletest.hpp"
 
 using namespace httpserver;
 using namespace std;

--- a/test/unit/http_utils_test.cpp
+++ b/test/unit/http_utils_test.cpp
@@ -18,6 +18,8 @@
      USA
 */
 
+#include "httpserver/http_utils.hpp"
+
 #if defined(__MINGW32__) || defined(__CYGWIN32__)
 #define _WINDOWS
 #undef _WIN32_WINNT
@@ -28,10 +30,9 @@
 #include <arpa/inet.h>
 #endif
 
-#include "littletest.hpp"
-#include "httpserver/http_utils.hpp"
-
 #include <cstdio>
+
+#include "littletest.hpp"
 
 using namespace httpserver;
 using namespace std;

--- a/test/unit/string_utilities_test.cpp
+++ b/test/unit/string_utilities_test.cpp
@@ -18,10 +18,11 @@
      USA
 */
 
-#include "littletest.hpp"
 #include "httpserver/string_utilities.hpp"
 
 #include <cstdio>
+
+#include "littletest.hpp"
 
 using namespace httpserver;
 using namespace std;


### PR DESCRIPTION
# Identify the Bug

#177 (General code style issues)

### Description of the Change

Sort include (using the Google C++ style pattern).

The pattern I'm recommending is:
```
[if in foo.cpp or foo_test.cpp
#include <full/path/to/foo.hpp>
]

#include <c-headers.h>  
#include <c++header>

#include <local/headers.hpp> 
```

This is somewhat complicated by the `#if WINDOWS ...` stuff, but there wasn't many of those.

Also this shuffling surface some files that used symbols that were not defined in a header they included. It seems rather that they were depending on the needed header having already been included by something up the stack.

### Alternate Designs

Leaving it as whatever.

### Possible Drawbacks

It's possible this could break a consuming build somehow, however any break should be fixable by adding some needed header (probably in the consuming code) which should be done anyway.

### Verification Process

```
./bootstrap
mkdir build ; cs build
../configure
make
```

### Release Notes
Sort include (using the Google C++ style pattern).