### PR TITLE
Added missing no_single_resource method

### DIFF
--- a/src/httpserver/create_webserver.hpp
+++ b/src/httpserver/create_webserver.hpp
@@ -229,6 +229,10 @@ class create_webserver
         {
             _single_resource = true; return *this;
         }
+        create_webserver& no_single_resource()
+        {
+            _single_resource = false; return *this;
+        }
         create_webserver& tcp_nodelay()
         {
             _tcp_nodelay = true; return *this;


### PR DESCRIPTION
### Identify the Bug

The no_single_resource was missing from the create_webserver object.

See also: https://github.com/etr/libhttpserver/issues/189

### Description of the Change

Added the no_single_resource method

### Alternate Designs

Given that default is false, we could have left the method out but it might still be useful in complex configurations of the builder object.

### Possible Drawbacks

None.

### Verification Process

Unit tests

### Release Notes

Added the no_single_resource method to create_webserver
