### PR TITLE
feat(platform): add missing freebsd headers

### DIFF
--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -24,6 +24,9 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #else
+#if defined(__FreeBSD__)
+#include <netinet/in.h>
+#endif
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -25,6 +25,9 @@
 #include <ws2tcpip.h>
 #define _WINDOWS
 #else
+#if defined(__FreeBSD__)
+#include <netinet/in.h>
+#endif
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
 #endif


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <fzipitria@perceptyx.com>

### Identify the Bug

This PR fixes #191.

### Description of the Change

Only when compiling in FreeBSD, include the `netinet/in.h` header.

### Alternate Designs

None.

### Possible Drawbacks

None.

### Verification Process

Created patch. Compiled. Compilation finished properly.

### Release Notes

- Fixed compilation in FreeBSD.