### PR TITLE
Fix cygwin build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ case "$host" in
         native_srcdir=$(cd $srcdir; pwd -W)
         ;;
     *-cygwin*)
-        NETWORK_HEADER="winsock2.h"
+        NETWORK_HEADER="arpa/inet.h"
         REGEX_LIBS="-lregex -lpthread -no-undefined"
         ;;
     *)

--- a/configure.ac
+++ b/configure.ac
@@ -64,17 +64,17 @@ NETWORK_LIBS=""
 case "$host" in
     *-mingw*)
         NETWORK_HEADER="winsock2.h"
-        REGEX_LIBS="-lregex -lpthread -no-undefined"
+        ADDITIONAL_LIBS="-lpthread -no-undefined"
         NETWORK_LIBS="-lws2_32"
         native_srcdir=$(cd $srcdir; pwd -W)
         ;;
     *-cygwin*)
         NETWORK_HEADER="arpa/inet.h"
-        REGEX_LIBS="-lregex -lpthread -no-undefined"
+        ADDITIONAL_LIBS="-lpthread -no-undefined"
         ;;
     *)
         NETWORK_HEADER="arpa/inet.h"
-        REGEX_LIBS=""
+        ADDITIONAL_LIBS=""
         is_windows=no
         ;;
 esac
@@ -86,7 +86,6 @@ AC_CHECK_HEADER([inttypes.h],[],[AC_MSG_ERROR("inttypes.h not found")])
 AC_CHECK_HEADER([errno.h],[],[AC_MSG_ERROR("errno.h not found")])
 AC_CHECK_HEADER([unistd.h],[],[AC_MSG_ERROR("unistd.h not found")])
 AC_CHECK_HEADER([ctype.h],[],[AC_MSG_ERROR("cctype not found")])
-AC_CHECK_HEADER([regex.h],[],[AC_MSG_ERROR("regex.h not found")])
 AC_CHECK_HEADER([sys/stat.h],[],[AC_MSG_ERROR("sys/stat.h not found")])
 AC_CHECK_HEADER([sys/types.h],[],[AC_MSG_ERROR("sys/types.h not found")])
 AC_CHECK_HEADER([$NETWORK_HEADER],[],[AC_MSG_ERROR("$NETWORK_HEADER not found")])
@@ -117,7 +116,7 @@ if test x"$host" = x"$build"; then
     )
 
     CXXFLAGS="-std=c++11 -DHTTPSERVER_COMPILATION -D_REENTRANT $LIBMICROHTTPD_CFLAGS $CXXFLAGS"
-    LDFLAGS="$LIBMICROHTTPD_LIBS $NETWORK_LIBS $REGEX_LIBS $LDFLAGS"
+    LDFLAGS="$LIBMICROHTTPD_LIBS $NETWORK_LIBS $ADDITIONAL_LIBS $LDFLAGS"
 
     cond_cross_compile="no"
 else
@@ -130,7 +129,7 @@ else
     )
 
     CXXFLAGS="-std=c++11 -DHTTPSERVER_COMPILATION -D_REENTRANT $CXXFLAGS"
-    LDFLAGS="$NETWORK_LIBS $REGEX_LIBS $LDFLAGS"
+    LDFLAGS="$NETWORK_LIBS $ADDITIONAL_LIBS $LDFLAGS"
 
     cond_cross_compile="yes"
 fi

--- a/src/details/http_endpoint.cpp
+++ b/src/details/http_endpoint.cpp
@@ -115,7 +115,7 @@ http_endpoint::http_endpoint
     if(use_regex)
     {
         url_normalized += "$";
-        re_url_normalized = std::regex(url_normalized, std::regex::extended | syntax_option_type icase | syntax_option_type nosubs);
+        re_url_normalized = std::regex(url_normalized, std::regex::extended | std::regex::icase | std::regex::nosubs);
         reg_compiled = true;
     }
 }
@@ -128,7 +128,7 @@ http_endpoint::http_endpoint(const http_endpoint& h):
     chunk_positions(h.chunk_positions),
     family_url(h.family_url),
     reg_compiled(h.reg_compiled),
-    re_url_normalized(h.re_url_normalize)
+    re_url_normalized(h.re_url_normalized)
 {
 }
 

--- a/src/details/http_endpoint.cpp
+++ b/src/details/http_endpoint.cpp
@@ -115,7 +115,7 @@ http_endpoint::http_endpoint
     if(use_regex)
     {
         url_normalized += "$";
-        re_url_normalized = std::basic_regex(url_normalized, std::regex::extended | syntax_option_type icase | syntax_option_type nosubs);
+        re_url_normalized = std::regex(url_normalized, std::regex::extended | syntax_option_type icase | syntax_option_type nosubs);
         reg_compiled = true;
     }
 }

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -52,9 +52,16 @@
 #define CLEAR_BIT(var,pos) ((var) &= ~(1<<(pos)))
 
 #if defined (__CYGWIN__)
+
 #if ! defined (NI_MAXHOST)
 #define NI_MAXHOST 1025
 #endif // NI_MAXHOST
+
+#ifndef __u_char_defined
+typedef unsigned char u_char;
+#define __u_char_defined
+#endif // __u_char_defined
+
 #endif // CYGWIN
 
 using namespace std;

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -27,6 +27,9 @@
 #if defined(__FreeBSD__)
 #include <netinet/in.h>
 #endif
+#if defined(__CYGWIN__)
+#include <sys/select.h>
+#endif
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -27,6 +27,9 @@
 #if defined(__FreeBSD__)
 #include <netinet/in.h>
 #endif
+#if defined(__CYGWIN__)
+#include <netdb.h>
+#endif
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -27,9 +27,6 @@
 #if defined(__FreeBSD__)
 #include <netinet/in.h>
 #endif
-#if defined(__CYGWIN__)
-#include <sys/select.h>
-#endif
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -23,17 +23,16 @@
 #if defined(_WIN32) && ! defined(__CYGWIN__)
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#else
+#else // WIN32 check
 #if defined(__FreeBSD__)
 #include <netinet/in.h>
-#endif
-#if defined(__CYGWIN__)
-#include <netdb.h>
-#endif
-#include <sys/socket.h>
-#include <netdb.h>
+#endif // FreeBSD
 #include <arpa/inet.h>
-#endif
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#endif // WIN32 check
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -43,6 +42,7 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 #include "httpserver/string_utilities.hpp"
 
@@ -50,6 +50,12 @@
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 #define SET_BIT(var,pos) ((var) |= 1 << (pos))
 #define CLEAR_BIT(var,pos) ((var) &= ~(1<<(pos)))
+
+#if defined (__CYGWIN__)
+#if ! defined (NI_MAXHOST)
+#define NI_MAXHOST 1025
+#endif // NI_MAXHOST
+#endif // CYGWIN
 
 using namespace std;
 

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -20,7 +20,7 @@
 
 #include "httpserver/http_utils.hpp"
 
-#if defined(__MINGW32__) || defined(__CYGWIN32__)
+#if defined(_WIN32) && ! defined(__CYGWIN__)
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #else

--- a/src/httpserver/details/http_endpoint.hpp
+++ b/src/httpserver/details/http_endpoint.hpp
@@ -137,7 +137,8 @@ class http_endpoint
             url_complete("/"),
             url_normalized("/"),
             family_url(false),
-            reg_compiled(false)
+            reg_compiled(false),
+            re_url_normalized(std::basic_regex()) // initialize empty
         {
         }
 

--- a/src/httpserver/details/http_endpoint.hpp
+++ b/src/httpserver/details/http_endpoint.hpp
@@ -136,9 +136,9 @@ class http_endpoint
         http_endpoint():
             url_complete("/"),
             url_normalized("/"),
+            re_url_normalized(std::regex("")), // initialize empty
             family_url(false),
-            reg_compiled(false),
-            re_url_normalized(std::regex("")) // initialize empty
+            reg_compiled(false)
         {
         }
 

--- a/src/httpserver/details/http_endpoint.hpp
+++ b/src/httpserver/details/http_endpoint.hpp
@@ -25,7 +25,7 @@
 #ifndef _HTTP_ENDPOINT_HPP_
 #define _HTTP_ENDPOINT_HPP_
 
-#include <regex.h>
+#include <regex>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -186,7 +186,7 @@ class http_endpoint
         /**
          * Regex used in comparisons
         **/
-        regex_t re_url_normalized;
+        std::basic_regex re_url_normalized;
 
         /**
          * Boolean indicating wheter the endpoint represents a family

--- a/src/httpserver/details/http_endpoint.hpp
+++ b/src/httpserver/details/http_endpoint.hpp
@@ -138,7 +138,7 @@ class http_endpoint
             url_normalized("/"),
             family_url(false),
             reg_compiled(false),
-            re_url_normalized(std::basic_regex()) // initialize empty
+            re_url_normalized(std::regex("")) // initialize empty
         {
         }
 
@@ -187,7 +187,7 @@ class http_endpoint
         /**
          * Regex used in comparisons
         **/
-        std::basic_regex re_url_normalized;
+        std::regex re_url_normalized;
 
         /**
          * Boolean indicating wheter the endpoint represents a family

--- a/src/httpserver/http_utils.hpp
+++ b/src/httpserver/http_utils.hpp
@@ -37,6 +37,11 @@
 #define _WIN32_WINNT 0x600
 #endif
 
+// needed to have the fd_set definition ahead of microhttpd.h import
+#if defined(__CYGWIN__)
+#include <sys/select.h>
+#endif
+
 #include <microhttpd.h>
 #include <algorithm>
 #include <cctype>
@@ -72,7 +77,7 @@ class http_utils
 
     enum start_method_T
     {
-#if defined(__MINGW32__) || defined(__CYGWIN32__)
+#if defined(__MINGW32__) || defined(__CYGWIN__)
     #ifdef ENABLE_POLL
         INTERNAL_SELECT = MHD_USE_SELECT_INTERNALLY | MHD_USE_POLL,
     #else

--- a/src/httpserver/string_utilities.hpp
+++ b/src/httpserver/string_utilities.hpp
@@ -44,9 +44,6 @@ const std::string to_lower_copy(const std::string& str);
 const std::vector<std::string> string_split(const std::string& s,
         char sep = ' ', bool collapse = true
 );
-const std::string regex_replace(const std::string& str, const std::string& pattern,
-        const std::string& replace_str
-);
 void to_upper(std::string& str);
 };
 };

--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -174,7 +174,6 @@ class webserver
         bool single_resource;
         bool tcp_nodelay;
         pthread_mutex_t mutexwait;
-        pthread_rwlock_t runguard;
         pthread_cond_t mutexcond;
         render_ptr not_found_resource;
         render_ptr method_not_allowed_resource;

--- a/src/string_utilities.cpp
+++ b/src/string_utilities.cpp
@@ -20,7 +20,6 @@
 
 #include "httpserver/string_utilities.hpp"
 
-#include <regex.h>
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
@@ -82,44 +81,6 @@ const std::vector<std::string> string_split(
         if((collapse && token != "") || !collapse)
             result.push_back(token);
     }
-    return result;
-}
-
-const std::string regex_replace(const std::string& str,
-        const std::string& pattern,
-        const std::string& replace_str
-)
-{
-    regex_t preg;
-    regmatch_t substmatch[1];
-    regcomp(&preg, pattern.c_str(), REG_EXTENDED|REG_ICASE);
-    std::string result;
-    if ( regexec(&preg, str.c_str(), 1, substmatch, 0) == 0 )
-    {
-        char ns[substmatch[0].rm_so + 1 +
-            replace_str.size() + (str.size() - substmatch[0].rm_eo) + 2
-        ];
-
-        memcpy(ns, str.c_str(), substmatch[0].rm_so+1);
-
-        memcpy(&ns[substmatch[0].rm_so],
-                replace_str.c_str(),
-                replace_str.size()
-        );
-
-        memcpy(&ns[substmatch[0].rm_so+replace_str.size()],
-                &str[substmatch[0].rm_eo], str.substr(substmatch[0].rm_eo).size()
-        );
-
-        ns[substmatch[0].rm_so +
-            replace_str.size() +
-            str.substr(substmatch[0].rm_eo).size()
-        ] = 0;
-
-        result = std::string((char*)ns);
-    }
-    regfree(&preg);
-
     return result;
 }
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -50,6 +50,13 @@
 #include <unistd.h>
 #include <algorithm>
 #include <iostream>
+#include <strings.h>
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
 
 #include "gettext.h"
 #include "httpserver/create_webserver.hpp"

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -20,7 +20,7 @@
 
 #include "httpserver/webserver.hpp"
 
-#if defined(__MINGW32__) || defined(__CYGWIN32__)
+#if defined(_WIN32) && ! defined(__CYGWIN__)
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #define _WINDOWS

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -91,7 +91,7 @@ struct compare_value
     }
 };
 
-#ifndef __MINGW32__
+#if !defined(_WIN32) && !defined(__MINGW32__) && !defined(__CYGWIN__)
 static void catcher (int sig)
 {
 }
@@ -100,7 +100,7 @@ static void catcher (int sig)
 static void ignore_sigpipe ()
 {
 //Mingw doesn't implement SIGPIPE
-#ifndef __MINGW32__
+#if !defined(_WIN32) && !defined(__MINGW32__) && !defined(__CYGWIN__)
     struct sigaction oldsig;
     struct sigaction sig;
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -170,7 +170,6 @@ webserver::webserver(const create_webserver& params):
 {
     ignore_sigpipe();
     pthread_mutex_init(&mutexwait, NULL);
-    pthread_rwlock_init(&runguard, NULL);
     pthread_cond_init(&mutexcond, NULL);
 }
 
@@ -178,7 +177,6 @@ webserver::~webserver()
 {
     stop();
     pthread_mutex_destroy(&mutexwait);
-    pthread_rwlock_destroy(&runguard);
     pthread_cond_destroy(&mutexcond);
 }
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -28,6 +28,9 @@
 #if defined(__FreeBSD__)
 #include <netinet/in.h>
 #endif
+#if defined(__CYGWIN__)
+#include <sys/select.h>
+#endif
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
 #endif

--- a/test/integ/authentication.cpp
+++ b/test/integ/authentication.cpp
@@ -18,7 +18,7 @@
      USA
 */
 
-#if defined(__MINGW32__) || defined(__CYGWIN32__)
+#if defined(_WIN32) && ! defined(__CYGWIN__)
 #define _WINDOWS
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x600

--- a/test/integ/deferred.cpp
+++ b/test/integ/deferred.cpp
@@ -18,7 +18,7 @@
      USA
 */
 
-#if defined(__MINGW32__) || defined(__CYGWIN32__)
+#if defined(_WIN32) && ! defined(__CYGWIN__)
 #define _WINDOWS
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x600

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -18,7 +18,7 @@
      USA
 */
 
-#if defined(__MINGW32__) || defined(__CYGWIN32__)
+#if defined(_WIN32) && ! defined(__CYGWIN__)
 #define _WINDOWS
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x600

--- a/test/unit/http_utils_test.cpp
+++ b/test/unit/http_utils_test.cpp
@@ -20,7 +20,7 @@
 
 #include "httpserver/http_utils.hpp"
 
-#if defined(__MINGW32__) || defined(__CYGWIN32__)
+#if defined(_WIN32) && ! defined(__CYGWIN__)
 #define _WINDOWS
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x600

--- a/test/unit/string_utilities_test.cpp
+++ b/test/unit/string_utilities_test.cpp
@@ -93,11 +93,6 @@ LT_BEGIN_AUTO_TEST(string_utilities_suite, split_string_end_space)
     LT_CHECK_COLLECTIONS_EQ(expected.begin(), expected.end(), actual.begin());
 LT_END_AUTO_TEST(split_string_end_space)
 
-LT_BEGIN_AUTO_TEST(string_utilities_suite, regex_replace)
-    LT_CHECK_EQ(string_utilities::regex_replace("test///message", "(\\/)+", "/"), "test/message");
-    LT_CHECK_EQ(string_utilities::regex_replace("test 1234 message", "([0-9])+", "bob"), "test bob message");
-LT_END_AUTO_TEST(regex_replace)
-
 LT_BEGIN_AUTO_TEST_ENV()
     AUTORUN_TESTS()
 LT_END_AUTO_TEST_ENV()


### PR DESCRIPTION
### Identify the Bug

* The library could not build on Cygwin

### Description of the Change

Enables the library to build on Cygwin.
Most of the changes relate with the optional inclusion of libraries that cygwin needs to build.
The most intrusive change has been removing regex.h in favor of C++11 regex.

### Alternate Designs

Do nothing and leave cygwin not to build.

### Possible Drawbacks

Build errors or malfunctioning due the intrusive change of regex.h. I am pretty confident of it not being a problem given the unit/integ test coverage of that area of the library.

### Verification Process

unit/integration testing and load testing on travis

### Release Notes

The library now builds on Cygwin (again!)