### PR TITLE
Fix regex in paths

### DIFF
--- a/src/details/http_endpoint.cpp
+++ b/src/details/http_endpoint.cpp
@@ -18,6 +18,8 @@
      USA
 */
 
+#include <stdexcept>
+
 #include "httpserver/details/http_endpoint.hpp"
 
 #include "httpserver/http_utils.hpp"
@@ -47,6 +49,11 @@ http_endpoint::http_endpoint
     family_url(family),
     reg_compiled(false)
 {
+    if (use_regex && !registration)
+    {
+        throw new std::invalid_argument("Cannot use regex if not during registration");
+    }
+
     url_normalized = use_regex ? "^/" : "/";
     vector<string> parts;
 
@@ -115,7 +122,14 @@ http_endpoint::http_endpoint
     if(use_regex)
     {
         url_normalized += "$";
-        re_url_normalized = std::regex(url_normalized, std::regex::extended | std::regex::icase | std::regex::nosubs);
+        try
+        {
+            re_url_normalized = std::regex(url_normalized, std::regex::extended | std::regex::icase | std::regex::nosubs);
+        }
+        catch (std::regex_error& e)
+        {
+            throw new std::invalid_argument("Not a valid regex in URL: " + url_normalized);
+        }
         reg_compiled = true;
     }
 }
@@ -126,9 +140,9 @@ http_endpoint::http_endpoint(const http_endpoint& h):
     url_pars(h.url_pars),
     url_pieces(h.url_pieces),
     chunk_positions(h.chunk_positions),
+    re_url_normalized(h.re_url_normalized),
     family_url(h.family_url),
-    reg_compiled(h.reg_compiled),
-    re_url_normalized(h.re_url_normalized)
+    reg_compiled(h.reg_compiled)
 {
 }
 

--- a/src/details/http_endpoint.cpp
+++ b/src/details/http_endpoint.cpp
@@ -51,7 +51,7 @@ http_endpoint::http_endpoint
 {
     if (use_regex && !registration)
     {
-        throw new std::invalid_argument("Cannot use regex if not during registration");
+        throw std::invalid_argument("Cannot use regex if not during registration");
     }
 
     url_normalized = use_regex ? "^/" : "/";
@@ -128,7 +128,7 @@ http_endpoint::http_endpoint
         }
         catch (std::regex_error& e)
         {
-            throw new std::invalid_argument("Not a valid regex in URL: " + url_normalized);
+            throw std::invalid_argument("Not a valid regex in URL: " + url_normalized);
         }
         reg_compiled = true;
     }

--- a/src/httpserver/details/http_endpoint.hpp
+++ b/src/httpserver/details/http_endpoint.hpp
@@ -156,7 +156,7 @@ class http_endpoint
         http_endpoint(const std::string& url,
                 bool family = false,
                 bool registration = false,
-                bool use_regex = true
+                bool use_regex = false
         );
     private:
         /**

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -378,7 +378,8 @@ bool webserver::stop()
 
 void webserver::unregister_resource(const string& resource)
 {
-    details::http_endpoint he(resource);
+    // family does not matter - it just checks the url_normalized anyhow
+    details::http_endpoint he(resource, false, true, regex_checking);
     registered_resources.erase(he);
     registered_resources.erase(he.get_url_complete());
     registered_resources_str.erase(he.get_url_complete());
@@ -621,7 +622,7 @@ int webserver::finalize_answer(
 
                 map<details::http_endpoint, http_resource*>::iterator found_endpoint;
 
-                details::http_endpoint endpoint(st_url, false, false, regex_checking);
+                details::http_endpoint endpoint(st_url, false, false, false);
 
                 map<details::http_endpoint, http_resource*>::iterator it;
 

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -993,6 +993,24 @@ LT_BEGIN_AUTO_TEST(basic_suite, long_path_pieces)
     curl_easy_cleanup(curl);
 LT_END_AUTO_TEST(long_path_pieces)
 
+LT_BEGIN_AUTO_TEST(basic_suite, url_with_regex_like_pieces)
+    path_pieces_resource resource;
+    ws->register_resource("/settings", &resource, true);
+    curl_global_init(CURL_GLOBAL_ALL);
+
+    std::string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/settings/{}");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(s, "settings,{},");
+    curl_easy_cleanup(curl);
+LT_END_AUTO_TEST(url_with_regex_like_pieces)
+
 LT_BEGIN_AUTO_TEST_ENV()
     AUTORUN_TESTS()
 LT_END_AUTO_TEST_ENV()

--- a/test/unit/http_endpoint_test.cpp
+++ b/test/unit/http_endpoint_test.cpp
@@ -50,8 +50,8 @@ LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_default)
     LT_CHECK_EQ(test_endpoint.is_regex_compiled(), false);
 LT_END_AUTO_TEST(http_endpoint_default)
 
-LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_from_string_default)
-    http_endpoint test_endpoint("/path/to/resource");
+LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_from_string_registration)
+    http_endpoint test_endpoint("/path/to/resource", false, true, true);
 
     LT_CHECK_EQ(test_endpoint.get_url_complete(), "/path/to/resource");
     LT_CHECK_EQ(test_endpoint.get_url_normalized(), "^/path/to/resource$");
@@ -66,10 +66,10 @@ LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_from_string_default)
 
     LT_CHECK_EQ(test_endpoint.is_family_url(), false);
     LT_CHECK_EQ(test_endpoint.is_regex_compiled(), true);
-LT_END_AUTO_TEST(http_endpoint_from_string_default)
+LT_END_AUTO_TEST(http_endpoint_from_string_registration)
 
 LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_from_string_not_beginning_with_slash)
-    http_endpoint test_endpoint("path/to/resource");
+    http_endpoint test_endpoint("path/to/resource", false, true, true);
 
     LT_CHECK_EQ(test_endpoint.get_url_complete(), "/path/to/resource");
     LT_CHECK_EQ(test_endpoint.get_url_normalized(), "^/path/to/resource$");
@@ -87,7 +87,7 @@ LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_from_string_not_beginning_
 LT_END_AUTO_TEST(http_endpoint_from_string_not_beginning_with_slash)
 
 LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_from_string_ending_with_slash)
-    http_endpoint test_endpoint("path/to/resource/");
+    http_endpoint test_endpoint("path/to/resource/", false, true, true);
 
     LT_CHECK_EQ(test_endpoint.get_url_complete(), "/path/to/resource");
     LT_CHECK_EQ(test_endpoint.get_url_normalized(), "^/path/to/resource$");
@@ -105,7 +105,7 @@ LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_from_string_ending_with_sl
 LT_END_AUTO_TEST(http_endpoint_from_string_ending_with_slash)
 
 LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_from_string_family)
-    http_endpoint test_endpoint("/path/to/resource", true);
+    http_endpoint test_endpoint("/path/to/resource", true, true, true);
 
     LT_CHECK_EQ(test_endpoint.get_url_complete(), "/path/to/resource");
     LT_CHECK_EQ(test_endpoint.get_url_normalized(), "^/path/to/resource$");
@@ -121,6 +121,24 @@ LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_from_string_family)
     LT_CHECK_EQ(test_endpoint.is_family_url(), true);
     LT_CHECK_EQ(test_endpoint.is_regex_compiled(), true);
 LT_END_AUTO_TEST(http_endpoint_from_string_family)
+
+LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_default_no_regex)
+    http_endpoint test_endpoint("/path/to/resource");
+
+    LT_CHECK_EQ(test_endpoint.get_url_complete(), "/path/to/resource");
+    LT_CHECK_EQ(test_endpoint.get_url_normalized(), "/path/to/resource");
+
+    LT_CHECK_EQ(test_endpoint.get_url_pars().size(), 0);
+
+    string expected_arr[] = { "path", "to", "resource" };
+    vector<string> expected_pieces(expected_arr, expected_arr + sizeof(expected_arr) / sizeof(expected_arr[0]));
+    LT_CHECK_COLLECTIONS_EQ(test_endpoint.get_url_pieces().begin(), test_endpoint.get_url_pieces().end(), expected_pieces.begin());
+
+    LT_CHECK_EQ(test_endpoint.get_chunk_positions().size(), 0);
+
+    LT_CHECK_EQ(test_endpoint.is_family_url(), false);
+    LT_CHECK_EQ(test_endpoint.is_regex_compiled(), false);
+LT_END_AUTO_TEST(http_endpoint_default_no_regex)
 
 LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_from_string_no_regex)
     http_endpoint test_endpoint("/path/to/resource", false, false, false);
@@ -141,7 +159,7 @@ LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_from_string_no_regex)
 LT_END_AUTO_TEST(http_endpoint_from_string_no_regex)
 
 LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_registration)
-    http_endpoint test_endpoint("/path/to/resource", false, true);
+    http_endpoint test_endpoint("/path/to/resource", false, true, true);
 
     LT_CHECK_EQ(test_endpoint.get_url_complete(), "/path/to/resource");
     LT_CHECK_EQ(test_endpoint.get_url_normalized(), "^/path/to/resource$");
@@ -159,7 +177,7 @@ LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_registration)
 LT_END_AUTO_TEST(http_endpoint_registration)
 
 LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_registration_nested_regex)
-    http_endpoint test_endpoint("/path/to/resource/with/[0-9]+/to/fetch", false, true);
+    http_endpoint test_endpoint("/path/to/resource/with/[0-9]+/to/fetch", false, true, true);
 
     LT_CHECK_EQ(test_endpoint.get_url_complete(), "/path/to/resource/with/[0-9]+/to/fetch");
     LT_CHECK_EQ(test_endpoint.get_url_normalized(), "^/path/to/resource/with/[0-9]+/to/fetch$");
@@ -177,7 +195,7 @@ LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_registration_nested_regex)
 LT_END_AUTO_TEST(http_endpoint_registration_nested_regex)
 
 LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_registration_arg)
-    http_endpoint test_endpoint("/path/to/resource/with/{arg}/to/fetch", false, true);
+    http_endpoint test_endpoint("/path/to/resource/with/{arg}/to/fetch", false, true, true);
 
     LT_CHECK_EQ(test_endpoint.get_url_complete(), "/path/to/resource/with/{arg}/to/fetch");
     LT_CHECK_EQ(test_endpoint.get_url_normalized(), "^/path/to/resource/with/([^\\/]+)/to/fetch$");
@@ -199,7 +217,7 @@ LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_registration_arg)
 LT_END_AUTO_TEST(http_endpoint_registration_arg)
 
 LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_registration_arg_custom_regex)
-    http_endpoint test_endpoint("/path/to/resource/with/{arg|([0-9]+)}/to/fetch", false, true);
+    http_endpoint test_endpoint("/path/to/resource/with/{arg|([0-9]+)}/to/fetch", false, true, true);
 
     LT_CHECK_EQ(test_endpoint.get_url_complete(), "/path/to/resource/with/{arg|([0-9]+)}/to/fetch");
     LT_CHECK_EQ(test_endpoint.get_url_normalized(), "^/path/to/resource/with/([0-9]+)/to/fetch$");
@@ -317,6 +335,10 @@ LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_match_regex_disabled)
     http_endpoint test_endpoint("/path/to/resource", false, true, false);
     LT_CHECK_THROW(test_endpoint.match(http_endpoint("/path/to/resource")));
 LT_END_AUTO_TEST(http_endpoint_match_regex_disabled)
+
+LT_BEGIN_AUTO_TEST(http_endpoint_suite, http_endpoint_cannot_use_regex_if_not_registering)
+    LT_CHECK_THROW(http_endpoint("/path/to/resource", false, false, true));
+LT_END_AUTO_TEST(http_endpoint_cannot_use_regex_if_not_registering)
 
 LT_BEGIN_AUTO_TEST(http_endpoint_suite, comparator)
     LT_CHECK_EQ(http_endpoint("/a/b") < http_endpoint("/a/c"), true);


### PR DESCRIPTION
### Identify the Bug

https://github.com/etr/libhttpserver/issues/196

### Description of the Change

This prevents the webserver class from compiling a regex object every time a URL in input is parsed. This should be done only at registration time. Preventing this defends the webserver from the potential DOS threat highlighted in the issue. 

Also added code that prevents (a) the error from ever being repeated in code by effectively throwing an exception if an http_endpoint is constructed with regex enabled outside of registration and (b) throwing an exception if a regex is malformed.

### Possible Drawbacks

If someone was using the http_endpoint class directly this might cause them issues. This is not a real problem though as the http_endpoint is a "details" class and should not be used directly by any consuming code so we do not guarantee backward compatibility on that class.

### Verification Process

Manual testing + unit/integration testing on travis.

### Release Notes

Fixed issue with malformed URLs received in input through HTTP requests. These were parsed as regex and caused the server to abort which could result in denial-of-service.