### PR TITLE
Compatibility with libmicrohttpd 0.9.71

### DIFF
--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -88,7 +88,7 @@ const std::string http_request::get_connection_value(const std::string& key, enu
     return header_c;
 }
 
-int http_request::build_request_header(
+MHD_Result http_request::build_request_header(
         void *cls,
         enum MHD_ValueKind kind,
         const char *key,
@@ -189,7 +189,7 @@ const std::string http_request::get_querystring() const
     return querystring;
 }
 
-int http_request::build_request_args(
+MHD_Result http_request::build_request_args(
         void *cls,
         enum MHD_ValueKind kind,
         const char *key,
@@ -204,7 +204,7 @@ int http_request::build_request_args(
     return MHD_YES;
 }
 
-int http_request::build_request_querystring(
+MHD_Result http_request::build_request_querystring(
         void *cls,
         enum MHD_ValueKind kind,
         const char *key,

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -247,15 +247,15 @@ class http_request
 
         unescaper_ptr unescaper = 0x0;
 
-        static int build_request_header(void *cls, enum MHD_ValueKind kind,
+        static MHD_Result build_request_header(void *cls, enum MHD_ValueKind kind,
                 const char *key, const char *value
         );
 
-        static int build_request_args(void *cls, enum MHD_ValueKind kind,
+        static MHD_Result build_request_args(void *cls, enum MHD_ValueKind kind,
                 const char *key, const char *value
         );
 
-        static int build_request_querystring(void *cls, enum MHD_ValueKind kind,
+        static MHD_Result build_request_querystring(void *cls, enum MHD_ValueKind kind,
                 const char *key, const char *value
         );
 

--- a/src/httpserver/http_utils.hpp
+++ b/src/httpserver/http_utils.hpp
@@ -53,6 +53,10 @@
 
 #define DEFAULT_MASK_VALUE 0xFFFF
 
+#if MHD_VERSION < 0x00097002
+typedef int MHD_Result;
+#endif
+
 namespace httpserver {
 
 typedef void(*unescaper_ptr)(std::string&);

--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -195,14 +195,14 @@ class webserver
                 enum MHD_RequestTerminationCode toe
         );
 
-        static int answer_to_connection
+        static MHD_Result answer_to_connection
         (
             void* cls, MHD_Connection* connection,
             const char* url, const char* method,
             const char* version, const char* upload_data,
             size_t* upload_data_size, void** con_cls
         );
-        static int post_iterator
+        static MHD_Result post_iterator
         (
             void *cls,
             enum MHD_ValueKind kind,
@@ -219,25 +219,25 @@ class webserver
             void **con_cls, int upgrade_socket
         );
 
-        int requests_answer_first_step(MHD_Connection* connection,
+        MHD_Result requests_answer_first_step(MHD_Connection* connection,
                 struct details::modded_request* mr
         );
 
-        int requests_answer_second_step(MHD_Connection* connection,
+        MHD_Result requests_answer_second_step(MHD_Connection* connection,
             const char* method, const char* version, const char* upload_data,
             size_t* upload_data_size, struct details::modded_request* mr
         );
 
-        int finalize_answer(MHD_Connection* connection,
+        MHD_Result finalize_answer(MHD_Connection* connection,
                 struct details::modded_request* mr, const char* method
         );
 
-        int complete_request(MHD_Connection* connection,
+        MHD_Result complete_request(MHD_Connection* connection,
                 struct details::modded_request* mr,
                 const char* version, const char* method
         );
 
-        friend int policy_callback (void *cls,
+        friend MHD_Result policy_callback (void *cls,
                 const struct sockaddr* addr, socklen_t addrlen
         );
         friend void error_log(void* cls, const char* fmt, va_list ap);


### PR DESCRIPTION
From the libmicrohttpd 0.9.71 release notes:

```
Furthermore, the release introduces an 'enum MHD_Result' instead of
#defines for MHD_YES/MHD_NO. This is intended to make it easier to check
for certain API misuse bugs by providing better types (not everything is
an 'int').  While this does NOT change the binary API, this change
_will_ cause compiler warnings for all legacy code -- until 'int' is
replaced with 'enum MHD_Result'
```

### Identify the Bug

https://github.com/etr/libhttpserver/issues/198
<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change
Replace 'int' with 'enum MHD_Result'

### Release Notes
Add compatibility with libmicrohttpd 0.9.71