### PR TITLE
Allow to avoid a string copy in string_response constructor

### DIFF
--- a/src/httpserver/string_response.hpp
+++ b/src/httpserver/string_response.hpp
@@ -36,12 +36,12 @@ class string_response : public http_response
         string_response() = default;
 
         explicit string_response(
-                const std::string& content,
+                std::string content,
                 int response_code = http::http_utils::http_ok,
                 const std::string& content_type = http::http_utils::text_plain
         ):
             http_response(response_code, content_type),
-            content(content)
+            content(std::move(content))
         {
         }
 


### PR DESCRIPTION
### Description of the Change

For the `string_response` constructor, instead of using a const reference, pass the string content by value (hence can be moved into) and move it into the `content` field. This allow to avoid a copy by doing things like

```
string_response my_response(std::move(my_string));
```

### Quantitative Performance Benefits

I ran benchmarks with gatling against my own application using libhttpserver as a frontend for the application backed by a mongo DB. Each run is 60 seconds. Used 10k and 10MB responses. Between 10 and 50 gatling clients. Performance gain is 3% to 5% depending on the setup.

If you have a standard way to run benchmarks I would be happy to run those.

### Possible Drawbacks

I don't see any drawbacks.

### Verification Process

It passes my own test suites. Sorry I was unable to run libhttpserver tests, I got unexpected errors when running `make check`, e.g `undefined reference to httpserver::resource_init...`

### Release Notes

Slight performances improvement by allowing to skip a copy in string_response constructor.

