### PR TITLE
Update configure and bootstrap, fix compiler warnings in http_endpoin…

### DIFF
--- a/README.CentOS-7
+++ b/README.CentOS-7
@@ -1,0 +1,7 @@
+## Cent OS 7 / RHEL 7
+
+CentOS 7 has a lower version of gcc (4.8.7) that is barely C++11 capable and this library
+needs a better compiler.  We recommend at least gcc 5+
+
+We recommend installing devtoolset-8
+https://www.softwarecollections.org/en/scls/rhscl/devtoolset-8/

--- a/README.FreeBSD
+++ b/README.FreeBSD
@@ -1,0 +1,9 @@
+## Building on FreeBSD (Tested on 12.0)
+
+# Due to the differences in the directory structures on BSD systems some minor tweaks need to occur
+# Also, FreeBSD and AIX "make" command is not compatible with gmake, like Linux and Mingw are
+
+export MAKE=gmake
+bootstrap
+configure CPPFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib
+gmake

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Additionally, clients can specify resource limits on the overall number of conne
 [Back to TOC](#table-of-contents)
 
 ## Requirements
-libhttpserver can be used without any dependencies aside for libmicrohttpd.
+libhttpserver can be used without any dependencies aside from libmicrohttpd.
 
 The minimum versions required are:
 * g++ >= 5.5.0 or clang-3.6
@@ -91,6 +91,8 @@ For versions before 0.18.0, on MinGW, you will need:
 * libgnurx >= 2.5.1
 
 Furthermore, the testcases use [libcurl](http://curl.haxx.se/libcurl/) but you don't need it to compile the library.
+
+Please refer to the readme file for your particular distribution if there is one for important notes.
 
 [Back to TOC](#table-of-contents)
 

--- a/bootstrap
+++ b/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #     This file is part of libhttpserver
 #     Copyright (C) 2011, 2012, 2013, 2014, 2015 Sebastiano Merlino

--- a/configure.ac
+++ b/configure.ac
@@ -284,6 +284,9 @@ case $host_os in
         AM_CXXFLAGS="$AM_CXXFLAGS -DDARWIN"
         AM_CFLAGS="$AM_CFLAGS -DDARWIN"
         ;;
+    freebsd* )
+        AM_LDFLAGS=""
+        ;;
 esac
 
 AC_MSG_CHECKING([whether to build with coverage information])

--- a/src/httpserver/deferred_response.hpp
+++ b/src/httpserver/deferred_response.hpp
@@ -70,7 +70,7 @@ class deferred_response : public string_response
         ssize_t (*cycle_callback)(std::shared_ptr<T>, char*, size_t);
         std::shared_ptr<T> closure_data;
 
-        static ssize_t cb(void* cls, uint64_t pos, char* buf, size_t max)
+        static ssize_t cb(void* cls, uint64_t, char* buf, size_t max)
         {
             deferred_response<T>* dfr = static_cast<deferred_response<T>*>(cls);
             return dfr->cycle_callback(dfr->closure_data, buf, max);

--- a/src/httpserver/details/http_endpoint.hpp
+++ b/src/httpserver/details/http_endpoint.hpp
@@ -120,12 +120,12 @@ class http_endpoint
             return chunk_positions;
         }
 
-        const bool is_family_url() const
+        const bool is_family_url()
         {
             return family_url;
         }
 
-        const bool is_regex_compiled() const
+        const bool is_regex_compiled()
         {
             return reg_compiled;
         }

--- a/src/httpserver/details/http_endpoint.hpp
+++ b/src/httpserver/details/http_endpoint.hpp
@@ -120,12 +120,12 @@ class http_endpoint
             return chunk_positions;
         }
 
-        const bool is_family_url()
+        bool is_family_url() const
         {
             return family_url;
         }
 
-        const bool is_regex_compiled()
+        bool is_regex_compiled() const
         {
             return reg_compiled;
         }


### PR DESCRIPTION
### Issue or RFC Endorsed by Maintainers

None

### Description of the Change

Updated some of the build scripts to be more portable and to build on FreeBSD.
Fixed a few compiler warnings
Added OS specific readmes for applicable issues to help users

### Alternate Designs

### Possible Drawbacks

Potentially break other platforms

### Verification Process

Built on FreeBSD 12, Fedora 32, CentOS 7, and Mingw64 (Windows 10)

### Release Notes

Added OS specific tips, and cleaned up some compiler warnings
