### PR TITLE
Fix heap buffer overflow

### DIFF
--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -33,6 +33,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <ctype.h>
 #include <fstream>
 #include <iomanip>
 #include <iterator>
@@ -304,12 +305,13 @@ size_t http_unescape(std::string& val)
 {
     if (val.empty()) return 0;
 
-    int rpos = 0;
-    int wpos = 0;
+    unsigned int rpos = 0;
+    unsigned int wpos = 0;
 
     unsigned int num;
+    unsigned int size = val.size();
 
-    while ('\0' != val[rpos])
+    while (rpos < size && val[rpos] != '\0')
     {
         switch (val[rpos])
         {
@@ -319,8 +321,8 @@ size_t http_unescape(std::string& val)
                 rpos++;
                 break;
             case '%':
-                if ( (1 == sscanf (val.substr(rpos + 1).c_str(), "%2x", &num)) ||
-                    (1 == sscanf (val.substr(rpos + 1).c_str(), "%2X", &num))
+                if (size > rpos + 2 && ((1 == sscanf (val.substr(rpos + 1, 2).c_str(), "%2x", &num)) ||
+                    (1 == sscanf (val.substr(rpos + 1, 2).c_str(), "%2X", &num)))
                 )
                 {
                     val[wpos] = (unsigned char) num;

--- a/test/unit/http_utils_test.cpp
+++ b/test/unit/http_utils_test.cpp
@@ -67,7 +67,7 @@ LT_BEGIN_AUTO_TEST(http_utils_suite, unescape)
 LT_END_AUTO_TEST(unescape)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, unescape_plus)
-    char* with_plus = (char*) malloc(6 * sizeof(char));
+    char* with_plus = (char*) malloc(4 * sizeof(char));
     sprintf(with_plus, "%s", "A+B");
     std::string string_with_plus = with_plus;
     int expected_size = http::http_unescape(string_with_plus);
@@ -81,6 +81,22 @@ LT_BEGIN_AUTO_TEST(http_utils_suite, unescape_plus)
     free(with_plus);
     free(expected);
 LT_END_AUTO_TEST(unescape_plus)
+
+LT_BEGIN_AUTO_TEST(http_utils_suite, unescape_partial_marker)
+    char* with_marker = (char*) malloc(6 * sizeof(char));
+    sprintf(with_marker, "%s", "A+B%0");
+    std::string string_with_marker = with_marker;
+    int expected_size = http::http_unescape(string_with_marker);
+
+    char* expected = (char*) malloc(6 * sizeof(char));
+    sprintf(expected, "%s", "A B%0");
+
+    LT_CHECK_EQ(string_with_marker, string(expected));
+    LT_CHECK_EQ(expected_size, 5);
+
+    free(with_marker);
+    free(expected);
+LT_END_AUTO_TEST(unescape_partial_marker)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, tokenize_url)
     string value = "test/this/url/here";


### PR DESCRIPTION
### Identify the Bug

Unescaping URLs fails causing a full abort of the server. This happens when URLs have incomplete patterns resembling escape sequences as it assumes the sequence to be complete.

### Description of the Change

Make the library immune from such error by checking the length of the string in input when unescaping.

### Alternate Designs

We could flip the escape/unescape logic (thus only running this once at endpoint registration). This alternative design would have performance benefits but it is out of the purpose of this change and will require more work. Given the urgency, the current solution is the best option (as it doesn't degrade performance and fixes the issue).

### Possible Drawbacks

None

### Verification Process

Unit tests + travis runs.

### Release Notes

Fixed heap buffer overflow when unescaping URLs containing partial escape sequences.