### PR TITLE
Add a getter to allow access to the gnutls_session_t.

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ The `http_request` class has a set of methods you will have access to when imple
 * _**const std::string** get_pass() **const**:_ Returns the `password` as self-identified through basic authentication. The content of the password header will be parsed only if basic authentication is enabled on the server (enabled by default).
 * _**const std::string** get_digested_user() **const**:_ Returns the `digested user` as self-identified through digest authentication. The content of the user header will be parsed only if digest authentication is enabled on the server (enabled by default).
 * _**bool** check_digest_auth(**const std::string&** realm, **const std::string&** password, **int** nonce_timeout, **bool*** reload_nonce) **const**:_ Allows to check the validity of the authentication token sent through digest authentication (if the provided values in the WWW-Authenticate header are valid and sound according to RFC2716). Takes in input the `realm` of validity of the authentication, the `password` as known to the server to compare against, the `nonce_timeout` to indicate how long the nonce is valid and `reload_nonce` a boolean that will be set by the method to indicate a nonce being reloaded. The method returns `true` if the authentication is valid, `false` otherwise.
+* _**gnutls_session_t** get_tls_session() **const**:_ Reurn the underlying TLS state of the current request for inspection.
 
 #### Example of handler reading arguments from a request
     #include <httpserver.hpp>

--- a/README.md
+++ b/README.md
@@ -563,8 +563,8 @@ The `http_request` class has a set of methods you will have access to when imple
 * _**const std::string** get_pass() **const**:_ Returns the `password` as self-identified through basic authentication. The content of the password header will be parsed only if basic authentication is enabled on the server (enabled by default).
 * _**const std::string** get_digested_user() **const**:_ Returns the `digested user` as self-identified through digest authentication. The content of the user header will be parsed only if digest authentication is enabled on the server (enabled by default).
 * _**bool** check_digest_auth(**const std::string&** realm, **const std::string&** password, **int** nonce_timeout, **bool*** reload_nonce) **const**:_ Allows to check the validity of the authentication token sent through digest authentication (if the provided values in the WWW-Authenticate header are valid and sound according to RFC2716). Takes in input the `realm` of validity of the authentication, the `password` as known to the server to compare against, the `nonce_timeout` to indicate how long the nonce is valid and `reload_nonce` a boolean that will be set by the method to indicate a nonce being reloaded. The method returns `true` if the authentication is valid, `false` otherwise.
-* _**gnutls_session_t** get_tls_session() **const**:_ Test if there is am underlying TLS state of the current request.
-* _**gnutls_session_t** get_tls_session() **const**:_ Reurn the underlying TLS state of the current request for inspection. (It is an error to call this if the state does not exist.)
+* _**gnutls_session_t** get_tls_session() **const**:_ Tests if there is am underlying TLS state of the current request.
+* _**gnutls_session_t** get_tls_session() **const**:_ Returns the underlying TLS state of the current request for inspection. (It is an error to call this if the state does not exist.)
 
 #### Example of handler reading arguments from a request
     #include <httpserver.hpp>

--- a/README.md
+++ b/README.md
@@ -563,7 +563,8 @@ The `http_request` class has a set of methods you will have access to when imple
 * _**const std::string** get_pass() **const**:_ Returns the `password` as self-identified through basic authentication. The content of the password header will be parsed only if basic authentication is enabled on the server (enabled by default).
 * _**const std::string** get_digested_user() **const**:_ Returns the `digested user` as self-identified through digest authentication. The content of the user header will be parsed only if digest authentication is enabled on the server (enabled by default).
 * _**bool** check_digest_auth(**const std::string&** realm, **const std::string&** password, **int** nonce_timeout, **bool*** reload_nonce) **const**:_ Allows to check the validity of the authentication token sent through digest authentication (if the provided values in the WWW-Authenticate header are valid and sound according to RFC2716). Takes in input the `realm` of validity of the authentication, the `password` as known to the server to compare against, the `nonce_timeout` to indicate how long the nonce is valid and `reload_nonce` a boolean that will be set by the method to indicate a nonce being reloaded. The method returns `true` if the authentication is valid, `false` otherwise.
-* _**gnutls_session_t** get_tls_session() **const**:_ Reurn the underlying TLS state of the current request for inspection.
+* _**gnutls_session_t** get_tls_session() **const**:_ Test if there is am underlying TLS state of the current request.
+* _**gnutls_session_t** get_tls_session() **const**:_ Reurn the underlying TLS state of the current request for inspection. (It is an error to call this if the state does not exist.)
 
 #### Example of handler reading arguments from a request
     #include <httpserver.hpp>

--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -212,6 +212,15 @@ const std::string http_request::get_digested_user() const {
     return digested_user;
 }
 
+#ifdef HAVE_GNUTLS
+gnutls_session_t http_request::get_tls_session() const
+{
+    const MHD_ConnectionInfo * conninfo = MHD_get_connection_info(underlying_connection, MHD_CONNECTION_INFO_GNUTLS_SESSION);
+
+    return static_cast<gnutls_session_t>(conninfo->tls_session);
+}
+#endif  //HAVE_GNUTLS
+
 const std::string http_request::get_requestor() const {
     const MHD_ConnectionInfo * conninfo = MHD_get_connection_info(underlying_connection, MHD_CONNECTION_INFO_CLIENT_ADDRESS);
 

--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -213,6 +213,11 @@ const std::string http_request::get_digested_user() const {
 }
 
 #ifdef HAVE_GNUTLS
+bool http_request::has_tls_session() const {
+    const MHD_ConnectionInfo * conninfo = MHD_get_connection_info(underlying_connection, MHD_CONNECTION_INFO_GNUTLS_SESSION);
+    return (conninfo != nullptr);
+}
+
 gnutls_session_t http_request::get_tls_session() const {
     const MHD_ConnectionInfo * conninfo = MHD_get_connection_info(underlying_connection, MHD_CONNECTION_INFO_GNUTLS_SESSION);
 

--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -219,7 +219,7 @@ gnutls_session_t http_request::get_tls_session() const
 
     return static_cast<gnutls_session_t>(conninfo->tls_session);
 }
-#endif  //HAVE_GNUTLS
+#endif  // HAVE_GNUTLS
 
 const std::string http_request::get_requestor() const {
     const MHD_ConnectionInfo * conninfo = MHD_get_connection_info(underlying_connection, MHD_CONNECTION_INFO_CLIENT_ADDRESS);

--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -213,8 +213,7 @@ const std::string http_request::get_digested_user() const {
 }
 
 #ifdef HAVE_GNUTLS
-gnutls_session_t http_request::get_tls_session() const
-{
+gnutls_session_t http_request::get_tls_session() const {
     const MHD_ConnectionInfo * conninfo = MHD_get_connection_info(underlying_connection, MHD_CONNECTION_INFO_GNUTLS_SESSION);
 
     return static_cast<gnutls_session_t>(conninfo->tls_session);

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -189,6 +189,12 @@ class http_request {
 
 #ifdef HAVE_GNUTLS
      /**
+      * Method used to check if there is a TLS session.
+      * @return the TLS session
+      **/
+      bool has_tls_session() const;
+
+     /**
       * Method used to get the TLS session.
       * @return the TLS session
       **/

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -27,6 +27,10 @@
 
 #include <microhttpd.h>
 
+#ifdef HAVE_GNUTLS
+#include <gnutls/gnutls.h>
+#endif  // HAVE_GNUTLS
+
 #include <stddef.h>
 #include <algorithm>
 #include <iosfwd>
@@ -182,6 +186,14 @@ class http_request {
      const std::string& get_version() const {
          return version;
      }
+
+#ifdef HAVE_GNUTLS
+     /**
+      * Method used to get the TLS session.
+      * @return the TLS session
+      **/
+      gnutls_session_t get_tls_session() const;
+#endif  // HAVE_GNUTLS
 
      /**
       * Method used to get the requestor.


### PR DESCRIPTION
### Description of the Change

Add a method to yield a handle to the TLS sessions being used by libmicrohttpd for the request,

### Alternate Designs

I considered building API's the provide C++ wrappers for the specific TLS API's that would be needed but concluded that is not the job of this library.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
I ran a server using the new method to log data about the session.

    class hello_world_resource : public httpserver::http_resource {
     public:
      const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) override {
        auto tls = req.get_tls_session();
        LOG(INFO) << "Verion: " << gnutls_protocol_get_name(gnutls_protocol_get_version(tls));
        auto type = gnutls_certificate_type_get(tls);
        LOG(INFO) << "CertType: " << gnutls_certificate_type_get_name(type);
        unsigned int cert_count;
        auto* certs = gnutls_certificate_get_peers(tls, &cert_count);
        LOG(INFO) << "CertCount(Client): " << cert_count;
        // etc ...
      }
    };

    ....

    httpserver::webserver ws = httpserver::create_webserver(port)
                .debug()
                .log_error(+[](const std::string& err){
                  std::cout << err << std::endl;
                })
                .use_ssl()
                .raw_https_mem_key(std::string{tls_server_self_signed_cert_key_pem()})
                .raw_https_mem_cert(std::string{tls_server_self_signed_cert_pem()})
                .start_method(httpserver::http::http_utils::INTERNAL_SELECT)
                .max_threads(5);

    hello_world_resource hwr;
    ws.register_resource("/hello", &hwr, true);
    ws.start(true);

And got:

    I20210517 20:59:25.343529 20745 server.cc:74] Verion: TLS1.2
    I20210517 20:59:25.343542 20745 server.cc:77] CertType: X.509
    I20210517 20:59:25.343555 20745 server.cc:81] CertCount(Client): 0

(This is a brand new API, with exactly 2 lines of non-declaration and no flow control.  It's either works or it doesn't.)

### Release Notes

  Add httpserver::http_request::get_tls_session() to allow access to full TLS session.
