### PR TITLE
webserver: Fix garbage output on debug print

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -525,7 +525,7 @@ MHD_Result webserver::requests_answer_second_step(MHD_Connection* connection, co
 
     if (mr->has_body) {
 #ifdef DEBUG
-        std::cout << "Writing content: " << upload_data << std::endl;
+        std::cout << "Writing content: " << std::string(upload_data, *upload_data_size) << std::endl;
 #endif  // DEBUG
         mr->dhr->grow_content(upload_data, *upload_data_size);
 


### PR DESCRIPTION
### Identify the Bug

#242 

### Description of the Change

Consider the upload date size passed by libmicrohttpd to construct a std::string, instead of blindly relying on null termination.

### Alternate Designs

N/A

### Possible Drawbacks

*unsure*

### Verification Process

Logging output with that fix:

```
Writing content: {"login":{"pass":"admin","user":"admin"}}
Writing content: {"login":{"pass":"admin","user":"admin"}}
```

(See #242 for how it was before.)

### Release Notes

N/A
