### PR TITLE
WIP: Draft new file upload handling

### DIFF
--- a/src/httpserver/create_webserver.hpp
+++ b/src/httpserver/create_webserver.hpp
@@ -296,6 +296,11 @@ class create_webserver {
          return *this;
      }
 
+     create_webserver& post_upload_dir(const std::string& post_upload_dir) {
+         _post_upload_dir = post_upload_dir;
+         return *this;
+     }
+
      create_webserver& single_resource() {
          _single_resource = true;
          return *this;
@@ -360,6 +365,7 @@ class create_webserver {
      bool _regex_checking = true;
      bool _ban_system_enabled = true;
      bool _post_process_enabled = true;
+     std::string _post_upload_dir = "";
      bool _deferred_enabled = false;
      bool _single_resource = false;
      bool _tcp_nodelay = false;

--- a/src/httpserver/details/modded_request.hpp
+++ b/src/httpserver/details/modded_request.hpp
@@ -25,6 +25,7 @@
 #ifndef SRC_HTTPSERVER_DETAILS_MODDED_REQUEST_HPP_
 #define SRC_HTTPSERVER_DETAILS_MODDED_REQUEST_HPP_
 
+#include <fstream>
 #include <string>
 #include <memory>
 
@@ -46,6 +47,9 @@ struct modded_request {
     std::shared_ptr<http_response> dhrs;
     bool second = false;
     bool has_body = false;
+
+    std::string fname;
+    std::ofstream ostrm;
 
     modded_request() = default;
 

--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -162,6 +162,7 @@ class webserver {
      const bool regex_checking;
      const bool ban_system_enabled;
      const bool post_process_enabled;
+     const std::string post_upload_dir;
      const bool deferred_enabled;
      bool single_resource;
      bool tcp_nodelay;


### PR DESCRIPTION
### Identify the Bug

#229

### Description of the Change

This is an attempt to address the current shortcomings of big file upload as already discussed in #229.

The idea is to avoid storing possibly huge file upload in memory, at least not by default. The post processor mechanism from libmicrohttpd is used for parsing mime-types *multipart/form-data* and *application/x-www-form-urlencoded* (don't reinvent the wheel!) and text based key/value pairs are put to args as usual. 

Parts with a filename should be written to some C++ stream, a file stream would fit my needs and is shown here as proof of concept. Maybe we want to generalize that somehow? Later?

Initial version of this PR is a draft as base for discussion.

### Alternate Designs

Open for suggestions.

### Possible Drawbacks

It is not possible to get the whole multipart/form-data through `http_request::get_content()` anymore.

### Verification Process

Works on the bench with an example app not shown here. Should be improved of course.

### Release Notes

*tbd*