### PR TITLE
Use keyword nullptr where possible

### DIFF
--- a/examples/service.cpp
+++ b/examples/service.cpp
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
     while ((c = getopt(argc, argv, "p:k:c:sv?")) != EOF) {
         switch (c) {
         case 'p':
-            port = strtoul(optarg, NULL, 10);
+            port = strtoul(optarg, nullptr, 10);
             break;
         case 'k':
             key = optarg;

--- a/src/deferred_response.cpp
+++ b/src/deferred_response.cpp
@@ -29,7 +29,7 @@ namespace httpserver {
 namespace details {
 
 MHD_Response* get_raw_response_helper(void* cls, ssize_t (*cb)(void*, uint64_t, char*, size_t)) {
-    return MHD_create_response_from_callback(MHD_SIZE_UNKNOWN, 1024, cb, cls, NULL);
+    return MHD_create_response_from_callback(MHD_SIZE_UNKNOWN, 1024, cb, cls, nullptr);
 }
 
 }  // namespace details

--- a/src/file_response.cpp
+++ b/src/file_response.cpp
@@ -35,7 +35,7 @@ MHD_Response* file_response::get_raw_response() {
     if (size) {
         return MHD_create_response_from_fd(size, fd);
     } else {
-        return MHD_create_response_from_buffer(0, 0x0, MHD_RESPMEM_PERSISTENT);
+        return MHD_create_response_from_buffer(0, nullptr, MHD_RESPMEM_PERSISTENT);
     }
 }
 

--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -58,7 +58,7 @@ bool http_request::check_digest_auth(const std::string& realm, const std::string
 const std::string http_request::get_connection_value(const std::string& key, enum MHD_ValueKind kind) const {
     const char* header_c = MHD_lookup_connection_value(underlying_connection, kind, key.c_str());
 
-    if (header_c == NULL) return EMPTY;
+    if (header_c == nullptr) return EMPTY;
 
     return header_c;
 }
@@ -140,7 +140,7 @@ MHD_Result http_request::build_request_args(void *cls, enum MHD_ValueKind kind, 
     std::ignore = kind;
 
     arguments_accumulator* aa = static_cast<arguments_accumulator*>(cls);
-    std::string value = ((arg_value == NULL) ? "" : arg_value);
+    std::string value = ((arg_value == nullptr) ? "" : arg_value);
 
     http::base_unescaper(&value, aa->unescaper);
     (*aa->arguments)[key] = value;
@@ -152,7 +152,7 @@ MHD_Result http_request::build_request_querystring(void *cls, enum MHD_ValueKind
     std::ignore = kind;
 
     std::string* querystring = static_cast<std::string*>(cls);
-    std::string value = ((arg_value == NULL) ? "" : arg_value);
+    std::string value = ((arg_value == nullptr) ? "" : arg_value);
 
     int buffer_size = std::string(key).size() + value.size() + 3;
     char* buf = new char[buffer_size];
@@ -170,14 +170,14 @@ MHD_Result http_request::build_request_querystring(void *cls, enum MHD_ValueKind
 }
 
 const std::string http_request::get_user() const {
-    char* username = 0x0;
-    char* password = 0x0;
+    char* username = nullptr;
+    char* password = nullptr;
 
     username = MHD_basic_auth_get_username_password(underlying_connection, &password);
-    if (password != 0x0) free(password);
+    if (password != nullptr) free(password);
 
     std::string user;
-    if (username != 0x0) user = username;
+    if (username != nullptr) user = username;
 
     free(username);
 
@@ -185,14 +185,14 @@ const std::string http_request::get_user() const {
 }
 
 const std::string http_request::get_pass() const {
-    char* username = 0x0;
-    char* password = 0x0;
+    char* username = nullptr;
+    char* password = nullptr;
 
     username = MHD_basic_auth_get_username_password(underlying_connection, &password);
-    if (username != 0x0) free(username);
+    if (username != nullptr) free(username);
 
     std::string pass;
-    if (password != 0x0) pass = password;
+    if (password != nullptr) pass = password;
 
     free(password);
 
@@ -200,11 +200,11 @@ const std::string http_request::get_pass() const {
 }
 
 const std::string http_request::get_digested_user() const {
-    char* digested_user_c = 0x0;
+    char* digested_user_c = nullptr;
     digested_user_c = MHD_digest_auth_get_username(underlying_connection);
 
     std::string digested_user = EMPTY;
-    if (digested_user_c != 0x0) {
+    if (digested_user_c != nullptr) {
         digested_user = digested_user_c;
         free(digested_user_c);
     }

--- a/src/http_response.cpp
+++ b/src/http_response.cpp
@@ -27,7 +27,7 @@
 namespace httpserver {
 
 MHD_Response* http_response::get_raw_response() {
-    return MHD_create_response_from_buffer(0, 0x0, MHD_RESPMEM_PERSISTENT);
+    return MHD_create_response_from_buffer(0, nullptr, MHD_RESPMEM_PERSISTENT);
 }
 
 void http_response::decorate_response(MHD_Response* response) {

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -345,8 +345,8 @@ ip_representation::ip_representation(const std::string& ip) {
                 }
 
                 if (parts[i].size() == 4) {
-                    pieces[y] = strtol((parts[i].substr(0, 2)).c_str(), NULL, 16);
-                    pieces[y+1] = strtol((parts[i].substr(2, 2)).c_str(), NULL, 16);
+                    pieces[y] = strtol((parts[i].substr(0, 2)).c_str(), nullptr, 16);
+                    pieces[y+1] = strtol((parts[i].substr(2, 2)).c_str(), nullptr, 16);
 
                     y += 2;
                 } else {
@@ -371,7 +371,7 @@ ip_representation::ip_representation(const std::string& ip) {
 
                             for (unsigned int ii = 0; ii < subparts.size(); ii++) {
                                 if (subparts[ii] != "*") {
-                                    pieces[y+ii] = strtol(subparts[ii].c_str(), NULL, 10);
+                                    pieces[y+ii] = strtol(subparts[ii].c_str(), nullptr, 10);
                                     if (pieces[y+ii] > 255) throw std::invalid_argument("IP is badly formatted. 255 is max value for ip part.");
                                 } else {
                                     CLEAR_BIT(mask, y+ii);
@@ -396,7 +396,7 @@ ip_representation::ip_representation(const std::string& ip) {
         if (parts.size() == 4) {
             for (unsigned int i = 0; i < parts.size(); i++) {
                 if (parts[i] != "*") {
-                    pieces[12+i] = strtol(parts[i].c_str(), NULL, 10);
+                    pieces[12+i] = strtol(parts[i].c_str(), nullptr, 10);
                     if (pieces[12+i] > 255) throw std::invalid_argument("IP is badly formatted. 255 is max value for ip part.");
                 } else {
                     CLEAR_BIT(mask, 12+i);
@@ -481,7 +481,7 @@ void dump_arg_map(std::ostream &os, const std::string &prefix, const std::map<st
 size_t base_unescaper(std::string* s, unescaper_ptr unescaper) {
     if ((*s)[0] == 0) return 0;
 
-    if (unescaper != 0x0) {
+    if (unescaper != nullptr) {
         unescaper(*s);
         return s->size();
     }

--- a/src/httpserver/create_webserver.hpp
+++ b/src/httpserver/create_webserver.hpp
@@ -335,11 +335,11 @@ class create_webserver {
      size_t _content_size_limit = static_cast<size_t>(-1);
      int _connection_timeout = DEFAULT_WS_TIMEOUT;
      int _per_IP_connection_limit = 0;
-     log_access_ptr _log_access = 0x0;
-     log_error_ptr _log_error = 0x0;
-     validator_ptr _validator = 0x0;
-     unescaper_ptr _unescaper = 0x0;
-     const struct sockaddr* _bind_address = 0x0;
+     log_access_ptr _log_access = nullptr;
+     log_error_ptr _log_error = nullptr;
+     validator_ptr _validator = nullptr;
+     unescaper_ptr _unescaper = nullptr;
+     const struct sockaddr* _bind_address = nullptr;
      int _bind_socket = 0;
      int _max_thread_stack_size = 0;
      bool _use_ssl = false;
@@ -363,9 +363,9 @@ class create_webserver {
      bool _deferred_enabled = false;
      bool _single_resource = false;
      bool _tcp_nodelay = false;
-     render_ptr _not_found_resource = 0x0;
-     render_ptr _method_not_allowed_resource = 0x0;
-     render_ptr _internal_error_resource = 0x0;
+     render_ptr _not_found_resource = nullptr;
+     render_ptr _method_not_allowed_resource = nullptr;
+     render_ptr _internal_error_resource = nullptr;
 
      friend class webserver;
 };

--- a/src/httpserver/details/modded_request.hpp
+++ b/src/httpserver/details/modded_request.hpp
@@ -35,14 +35,14 @@ namespace httpserver {
 namespace details {
 
 struct modded_request {
-    struct MHD_PostProcessor *pp = 0x0;
-    std::string* complete_uri = 0x0;
-    std::string* standardized_url = 0x0;
-    webserver* ws = 0x0;
+    struct MHD_PostProcessor *pp = nullptr;
+    std::string* complete_uri = nullptr;
+    std::string* standardized_url = nullptr;
+    webserver* ws = nullptr;
 
     const std::shared_ptr<http_response> (httpserver::http_resource::*callback)(const httpserver::http_request&);
 
-    http_request* dhr = 0x0;
+    http_request* dhr = nullptr;
     std::shared_ptr<http_response> dhrs;
     bool second = false;
     bool has_body = false;
@@ -56,7 +56,7 @@ struct modded_request {
     modded_request& operator=(modded_request&& b) = default;
 
     ~modded_request() {
-        if (NULL != pp) {
+        if (nullptr != pp) {
             MHD_destroy_post_processor(pp);
         }
         if (second) {

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -244,9 +244,9 @@ class http_request {
      size_t content_size_limit = static_cast<size_t>(-1);
      std::string version;
 
-     struct MHD_Connection* underlying_connection = 0x0;
+     struct MHD_Connection* underlying_connection = nullptr;
 
-     unescaper_ptr unescaper = 0x0;
+     unescaper_ptr unescaper = nullptr;
 
      static MHD_Result build_request_header(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
 

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -416,7 +416,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, request_with_header)
     curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
 
-    struct curl_slist *list = NULL;
+    struct curl_slist *list = nullptr;
     list = curl_slist_append(list, "MyHeader: MyValue");
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
@@ -502,7 +502,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
     CURL* curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, NULL);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, nullptr);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 0);
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -579,7 +579,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
     curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, NULL);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, nullptr);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 0);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -931,8 +931,8 @@ LT_BEGIN_AUTO_TEST(basic_suite, request_is_printable)
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
 
-    struct curl_slist *list = NULL;
-    list = curl_slist_append(NULL, "MyHeader: MyValue");
+    struct curl_slist *list = nullptr;
+    list = curl_slist_append(nullptr, "MyHeader: MyValue");
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
     res = curl_easy_perform(curl);
@@ -966,8 +966,8 @@ LT_BEGIN_AUTO_TEST(basic_suite, response_is_printable)
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
 
-    struct curl_slist *list = NULL;
-    list = curl_slist_append(NULL, "MyHeader: MyValue");
+    struct curl_slist *list = nullptr;
+    list = curl_slist_append(nullptr, "MyHeader: MyValue");
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
     res = curl_easy_perform(curl);

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -494,14 +494,14 @@ void* start_ws_blocking(void* par) {
     ws->register_resource("base", &ok);
     ws->start(true);
 
-    return 0x0;
+    return nullptr;
 }
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, blocking_server)
     httpserver::webserver ws = httpserver::create_webserver(8080);
 
     pthread_t tid;
-    pthread_create(&tid, NULL, start_ws_blocking, reinterpret_cast<void*>(&ws));
+    pthread_create(&tid, nullptr, start_ws_blocking, reinterpret_cast<void*>(&ws));
 
     sleep(1);
 

--- a/test/unit/http_utils_test.cpp
+++ b/test/unit/http_utils_test.cpp
@@ -193,7 +193,7 @@ LT_BEGIN_AUTO_TEST(http_utils_suite, ip_to_str_invalid_family)
 LT_END_AUTO_TEST(ip_to_str_invalid_family)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, ip_to_str_null)
-    LT_CHECK_THROW(httpserver::http::get_ip_str((struct sockaddr*) 0x0));
+    LT_CHECK_THROW(httpserver::http::get_ip_str((struct sockaddr*) nullptr));
 LT_END_AUTO_TEST(ip_to_str_null)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, get_port_invalid_family)
@@ -207,7 +207,7 @@ LT_BEGIN_AUTO_TEST(http_utils_suite, get_port_invalid_family)
 LT_END_AUTO_TEST(get_port_invalid_family)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, get_port_null)
-    LT_CHECK_THROW(httpserver::http::get_port((struct sockaddr*) 0x0));
+    LT_CHECK_THROW(httpserver::http::get_port((struct sockaddr*) nullptr));
 LT_END_AUTO_TEST(get_port_null)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, ip_representation4_str)


### PR DESCRIPTION
### Identify the Bug

#241 

### Description of the Change

Replace every usage of 0x0 or NULL with nullptr, which is available since C++11.  

`NULL`, or `0x0`, or `nullptr`, or even `0` was used over the entiry code base before for expressing the concept of a null pointer. Use the C++ special word **nullptr** instead to unify the code base and minimize friction with expectations of modern C++ developers.

### Alternate Designs

Using `NULL` instead would have been possible to unify the code base and show developer a null pointer is meant, but that's not C++ and it lacks the advantages of the nullptr keyword.

### Possible Drawbacks

Maybe such style changes are not desired? No functional drawbacks.

### Verification Process

Ran cpplint and unit tests.

### Release Notes

N/A
