### PR TITLE
file_response: Change default argument for content-type

### DIFF
--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -190,6 +190,7 @@ const char* http_utils::http_method_patch = MHD_HTTP_METHOD_PATCH;
 const char* http_utils::http_post_encoding_form_urlencoded = MHD_HTTP_POST_ENCODING_FORM_URLENCODED;
 const char* http_utils::http_post_encoding_multipart_formdata = MHD_HTTP_POST_ENCODING_MULTIPART_FORMDATA;
 
+const char* http_utils::application_octet_stream = "application/octet-stream";
 const char* http_utils::text_plain = "text/plain";
 
 std::vector<std::string> http_utils::tokenize_url(const std::string& str, const char separator) {

--- a/src/httpserver/file_response.hpp
+++ b/src/httpserver/file_response.hpp
@@ -40,7 +40,7 @@ class file_response : public http_response {
      explicit file_response(
              const std::string& filename,
              int response_code = http::http_utils::http_ok,
-             const std::string& content_type = http::http_utils::text_plain):
+             const std::string& content_type = http::http_utils::application_octet_stream):
          http_response(response_code, content_type),
          filename(filename) { }
 

--- a/src/httpserver/http_utils.hpp
+++ b/src/httpserver/http_utils.hpp
@@ -232,6 +232,7 @@ class http_utils {
      static const char* http_post_encoding_form_urlencoded;
      static const char* http_post_encoding_multipart_formdata;
 
+     static const char* application_octet_stream;
      static const char* text_plain;
 
      static std::vector<std::string> tokenize_url(const std::string&, const char separator = '/');

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -214,6 +214,13 @@ class file_response_resource_empty : public http_resource {
      }
 };
 
+class file_response_resource_default_content_type : public http_resource {
+ public:
+     const shared_ptr<http_response> render_GET(const http_request&) {
+         return shared_ptr<file_response>(new file_response("test_content", 200));
+     }
+};
+
 class exception_resource : public http_resource {
  public:
      const shared_ptr<http_response> render_GET(const http_request&) {
@@ -870,6 +877,24 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_empty)
     LT_CHECK_EQ(s, "");
     curl_easy_cleanup(curl);
 LT_END_AUTO_TEST(file_serving_resource_empty)
+
+LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_default_content_type)
+    file_response_resource_default_content_type resource;
+    ws->register_resource("base", &resource);
+    curl_global_init(CURL_GLOBAL_ALL);
+
+    map<string, string> ss;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, headerfunc);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &ss);
+    res = curl_easy_perform(curl);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(ss["Content-Type"], "application/octet-stream");
+    curl_easy_cleanup(curl);
+LT_END_AUTO_TEST(file_serving_resource_default_content_type)
 
 LT_BEGIN_AUTO_TEST(basic_suite, exception_forces_500)
     exception_resource resource;


### PR DESCRIPTION
### Identify the Bug

#248 

### Description of the Change

The constructor of class `file_response` can be used with default arguments. Content-type was set to *text/plain* before which is too specific for using the class with unknown files, and could lead to all kinds of broken behavior in different web browsers.

### Alternate Designs

MIME type *application/octet-stream* is what we used for that use-case successfully in different applications. Probably other MIME types starting with *application* would also work, but are not recommended.

### Possible Drawbacks

User might depend on the previous behavior.

### Verification Process

Added a test.

### Release Notes

- Class *file_response* changed default content-type from *text/plain* to *application/octet-stream*