### PR TITLE
Remove forced std=C++11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 #
 #     This file is part of libhttpserver
-#     Copyright (C) 2011, 2012, 2013, 2014, 2015 Sebastiano Merlino
+#     Copyright (C) 2011-2021 Sebastiano Merlino
 #
 #     This library is free software; you can redistribute it and/or
 #     modify it under the terms of the GNU Lesser General Public
@@ -118,7 +118,7 @@ if test x"$host" = x"$build"; then
         [AC_MSG_ERROR(["microhttpd.h not found"])]
     )
 
-    CXXFLAGS="-std=c++11 -DHTTPSERVER_COMPILATION -D_REENTRANT $LIBMICROHTTPD_CFLAGS $CXXFLAGS"
+    CXXFLAGS="-DHTTPSERVER_COMPILATION -D_REENTRANT $LIBMICROHTTPD_CFLAGS $CXXFLAGS"
     LDFLAGS="$LIBMICROHTTPD_LIBS $NETWORK_LIBS $ADDITIONAL_LIBS $LDFLAGS"
 
     cond_cross_compile="no"
@@ -131,7 +131,7 @@ else
         [AC_MSG_ERROR(["microhttpd.h not found"])]
     )
 
-    CXXFLAGS="-std=c++11 -DHTTPSERVER_COMPILATION -D_REENTRANT $CXXFLAGS"
+    CXXFLAGS="-DHTTPSERVER_COMPILATION -D_REENTRANT $CXXFLAGS"
     LDFLAGS="$NETWORK_LIBS $ADDITIONAL_LIBS $LDFLAGS"
 
     cond_cross_compile="yes"


### PR DESCRIPTION
### Identify the Bug

The library currently forces -std=c++11 during compile. This leads to issues as the current requirement is C++14 and both flags end-up being passed to the compiler. See: https://github.com/etr/libhttpserver/issues/245

### Description of the Change

This change removes the std=c++11 flag passed directly in configure.ac letting automake determine the correct flag.

### Alternate Designs

We could use the same approach and force c++14, but that will just re-iterate the issue.

### Possible Drawbacks

None that wouldn't emerge during compile time.

### Verification Process

Regular compile and test.

### Release Notes

Removed the std=c++11 flag forced in configure.ac letting automake determine the correct flag. 
