### PR TITLE
Remove --build option from bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -26,11 +26,3 @@ else
 fi
 automake --add-missing
 autoconf
-
-# Optionally do the build as well.
-if [ "$1" = "-build" -o "$1" = "--build" ] ; then
-    shift
-    ./configure "$@"
-    make
-    make check
-fi


### PR DESCRIPTION
### Identify the Bug

boostrap fails when passed the '--build' option. This is because it goes in conflict with the requirement to build in a separate directory.

See: https://github.com/etr/libhttpserver/issues/253

### Description of the Change

Given that the feature is mostly unused, this change removes it.

### Alternate Designs

We could have fixed the feature at the cost of additional complexity.

### Possible Drawbacks

Customers that were using this feature as part of their build system might see a failure in the upcoming version - albeit this seems hard given that the feature doesn't work. Converting to run the additional steps is simple enough.

### Verification Process

CI/CD.

### Release Notes

Removed '--build' option from the bootstrap script.