### PR TITLE
Fix warnings caused by libmicrohttpd v0.9.74

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,9 +56,9 @@ jobs:
 
     - name: Install libmicrohttpd dependency
       run: |
-        curl https://s3.amazonaws.com/libhttpserver/libmicrohttpd_releases/libmicrohttpd-0.9.59.tar.gz -o libmicrohttpd-0.9.59.tar.gz ;
-        tar -xzf libmicrohttpd-0.9.59.tar.gz ;
-        cd libmicrohttpd-0.9.59 ;
+        curl https://s3.amazonaws.com/libhttpserver/libmicrohttpd_releases/libmicrohttpd-0.9.64.tar.gz -o libmicrohttpd-0.9.64.tar.gz ;
+        tar -xzf libmicrohttpd-0.9.64.tar.gz ;
+        cd libmicrohttpd-0.9.64 ;
         ./configure --disable-examples ;
         make ;
         sudo make install ;

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,15 @@ jobs:
     - run: git checkout HEAD^2
       if: ${{ github.event_name == 'pull_request' }}
 
+    - name: Install libmicrohttpd dependency
+      run: |
+        curl https://s3.amazonaws.com/libhttpserver/libmicrohttpd_releases/libmicrohttpd-0.9.64.tar.gz -o libmicrohttpd-0.9.64.tar.gz ;
+        tar -xzf libmicrohttpd-0.9.64.tar.gz ;
+        cd libmicrohttpd-0.9.64 ;
+        ./configure --disable-examples ;
+        make ;
+        sudo make install ;
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
@@ -54,20 +63,11 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - name: Install libmicrohttpd dependency
-      run: |
-        curl https://s3.amazonaws.com/libhttpserver/libmicrohttpd_releases/libmicrohttpd-0.9.64.tar.gz -o libmicrohttpd-0.9.64.tar.gz ;
-        tar -xzf libmicrohttpd-0.9.64.tar.gz ;
-        cd libmicrohttpd-0.9.64 ;
-        ./configure --disable-examples ;
-        make ;
-        sudo make install ;
-
     - name: Manual steps to build the library
       run: |
         ./bootstrap ;
         ./configure --enable-same-directory-build;
         make ;
- 
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -396,20 +396,20 @@ jobs:
       id: cache-libmicrohttpd
       uses: actions/cache@v2
       with:
-        path: libmicrohttpd-0.9.59
+        path: libmicrohttpd-0.9.64
         key: ${{ matrix.os }}-${{ matrix.c-compiler }}-libmicrohttpd-pre-built
 
     - name: Build libmicrohttpd dependency (if not cached)
       run: |
-        curl https://s3.amazonaws.com/libhttpserver/libmicrohttpd_releases/libmicrohttpd-0.9.59.tar.gz -o libmicrohttpd-0.9.59.tar.gz ;
-        tar -xzf libmicrohttpd-0.9.59.tar.gz ;
-        cd libmicrohttpd-0.9.59 ;
+        curl https://s3.amazonaws.com/libhttpserver/libmicrohttpd_releases/libmicrohttpd-0.9.64.tar.gz -o libmicrohttpd-0.9.64.tar.gz ;
+        tar -xzf libmicrohttpd-0.9.64.tar.gz ;
+        cd libmicrohttpd-0.9.64 ;
         ./configure --disable-examples ;
         make ;
       if: steps.cache-libmicrohttpd.outputs.cache-hit != 'true'
       
     - name: Install libmicrohttpd
-      run: cd libmicrohttpd-0.9.59 ; sudo make install ;
+      run: cd libmicrohttpd-0.9.64 ; sudo make install ;
       
     - name: Refresh links to shared libs
       run: sudo ldconfig ;

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ libhttpserver can be used without any dependencies aside from libmicrohttpd.
 
 The minimum versions required are:
 * g++ >= 5.5.0 or clang-3.6
-* libmicrohttpd >= 0.9.53
+* libmicrohttpd >= 0.9.64
 * [Optionally]: for TLS (HTTPS) support, you'll need [libgnutls](http://www.gnutls.org/).
 * [Optionally]: to compile the code-reference, you'll need [doxygen](http://www.doxygen.nl/).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,9 @@ init:
 install:
   - 'if "%compiler%"=="msys2" C:\msys64\msys2_shell.cmd -defterm -no-start -msys2 -c "pacman --noconfirm -S --needed mingw-w64-$MSYS2_ARCH-{libtool,make,pkg-config,libsystre,doxygen,gnutls,graphviz,curl}"'
   - 'if "%compiler%"=="msys2" C:\msys64\msys2_shell.cmd -defterm -no-start -msys2 -c "pacman --noconfirm -S --needed autotools"'
-  - 'if "%compiler%"=="msys2" C:\msys64\msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c "cd $APPVEYOR_BUILD_FOLDER && curl https://s3.amazonaws.com/libhttpserver/libmicrohttpd_releases/libmicrohttpd-0.9.59.tar.gz -o libmicrohttpd-0.9.59.tar.gz"'
-  - 'if "%compiler%"=="msys2" C:\msys64\msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c "cd $APPVEYOR_BUILD_FOLDER && tar -xzf libmicrohttpd-0.9.59.tar.gz"'
-  - 'if "%compiler%"=="msys2" C:\msys64\msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c "cd $APPVEYOR_BUILD_FOLDER/libmicrohttpd-0.9.59 && ./configure --disable-examples --enable-poll=no --prefix /C/msys64 && make && make install"'
+  - 'if "%compiler%"=="msys2" C:\msys64\msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c "cd $APPVEYOR_BUILD_FOLDER && curl https://s3.amazonaws.com/libhttpserver/libmicrohttpd_releases/libmicrohttpd-0.9.64.tar.gz -o libmicrohttpd-0.9.64.tar.gz"'
+  - 'if "%compiler%"=="msys2" C:\msys64\msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c "cd $APPVEYOR_BUILD_FOLDER && tar -xzf libmicrohttpd-0.9.64.tar.gz"'
+  - 'if "%compiler%"=="msys2" C:\msys64\msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c "cd $APPVEYOR_BUILD_FOLDER/libmicrohttpd-0.9.64 && ./configure --disable-examples --enable-poll=no --prefix /C/msys64 && make && make install"'
   - 'if "%compiler%"=="msys2" C:\msys64\msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c "cd $APPVEYOR_BUILD_FOLDER && ./bootstrap"'
   - 'if "%compiler%"=="msys2" C:\msys64\msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c "cd $APPVEYOR_BUILD_FOLDER && mkdir build && cd build && MANIFEST_TOOL=no; ../configure --disable-fastopen --prefix /C/msys64 CXXFLAGS=-I/C/msys64/include LDFLAGS=-L/C/msys64/lib; make"'
 build_script:

--- a/configure.ac
+++ b/configure.ac
@@ -100,17 +100,17 @@ AC_CHECK_HEADER([gnutls/gnutls.h],[have_gnutls="yes"],[AC_MSG_WARN("gnutls/gnutl
 if test x"$host" = x"$build"; then
     AC_CHECK_HEADER([microhttpd.h],
         AC_CHECK_LIB([microhttpd], [MHD_get_fdset2],
-            [AC_MSG_CHECKING([for libmicrohttpd >= 0.9.53])
+            [AC_MSG_CHECKING([for libmicrohttpd >= 0.9.64])
                 AC_COMPILE_IFELSE(
                     [AC_LANG_SOURCE([
                         #include <microhttpd.h>
-                        #if (MHD_VERSION < 0x00095300)
-                        #error needs at least version 0.9.53
+                        #if (MHD_VERSION < 0x00096400)
+                        #error needs at least version 0.9.64
                         #endif
                         int main () { return 0; }
                     ])],
                 [],
-                [AC_MSG_ERROR("libmicrohttpd is too old - install libmicrohttpd >= 0.9.53")]
+                [AC_MSG_ERROR("libmicrohttpd is too old - install libmicrohttpd >= 0.9.64")]
                 )
             ],
             [AC_MSG_ERROR(["libmicrohttpd not found"])]

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -109,7 +109,6 @@ const int http_utils::http_expectation_failed = MHD_HTTP_EXPECTATION_FAILED;
 const int http_utils::http_unprocessable_entity = MHD_HTTP_UNPROCESSABLE_ENTITY;
 const int http_utils::http_locked = MHD_HTTP_LOCKED;
 const int http_utils::http_failed_dependency = MHD_HTTP_FAILED_DEPENDENCY;
-const int http_utils::http_unordered_collection = MHD_HTTP_UNORDERED_COLLECTION;
 const int http_utils::http_upgrade_required = MHD_HTTP_UPGRADE_REQUIRED;
 const int http_utils::http_retry_with = MHD_HTTP_RETRY_WITH;
 

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -61,6 +61,12 @@ typedef unsigned char u_char;
 
 #endif  // CYGWIN
 
+// libmicrohttpd deprecated some definitions with v0.9.74, and introduced new ones
+#if MHD_VERSION < 0x00097314
+#define MHD_HTTP_CONTENT_TOO_LARGE      MHD_HTTP_PAYLOAD_TOO_LARGE
+#define MHD_HTTP_UNPROCESSABLE_CONTENT  MHD_HTTP_UNPROCESSABLE_ENTITY
+#endif
+
 namespace httpserver {
 namespace http {
 
@@ -101,12 +107,12 @@ const int http_utils::http_conflict = MHD_HTTP_CONFLICT;
 const int http_utils::http_gone = MHD_HTTP_GONE;
 const int http_utils::http_length_required = MHD_HTTP_LENGTH_REQUIRED;
 const int http_utils::http_precondition_failed = MHD_HTTP_PRECONDITION_FAILED;
-const int http_utils::http_request_entity_too_large = MHD_HTTP_PAYLOAD_TOO_LARGE;
+const int http_utils::http_request_entity_too_large = MHD_HTTP_CONTENT_TOO_LARGE;
 const int http_utils::http_request_uri_too_long = MHD_HTTP_URI_TOO_LONG;
 const int http_utils::http_unsupported_media_type = MHD_HTTP_UNSUPPORTED_MEDIA_TYPE;
 const int http_utils::http_requested_range_not_satisfiable = MHD_HTTP_RANGE_NOT_SATISFIABLE;
 const int http_utils::http_expectation_failed = MHD_HTTP_EXPECTATION_FAILED;
-const int http_utils::http_unprocessable_entity = MHD_HTTP_UNPROCESSABLE_ENTITY;
+const int http_utils::http_unprocessable_entity = MHD_HTTP_UNPROCESSABLE_CONTENT;
 const int http_utils::http_locked = MHD_HTTP_LOCKED;
 const int http_utils::http_failed_dependency = MHD_HTTP_FAILED_DEPENDENCY;
 const int http_utils::http_upgrade_required = MHD_HTTP_UPGRADE_REQUIRED;

--- a/src/httpserver/http_utils.hpp
+++ b/src/httpserver/http_utils.hpp
@@ -150,7 +150,6 @@ class http_utils {
      static const int http_unprocessable_entity;
      static const int http_locked;
      static const int http_failed_dependency;
-     static const int http_unordered_collection;
      static const int http_upgrade_required;
      static const int http_retry_with;
 


### PR DESCRIPTION
### Identify the Bug

#176, #258 

### Description of the Change

This adds the same definitions as introduced with libmicrohttpd v0.9.74 if built against earlier versions of libmicrohttpd, at least for two out of three.  The other was not renamed in libmicrohttpd, but "removed".

### Alternate Designs

Do not rely on libmicrohttpd, but use integer literals directly.

### Possible Drawbacks

More compat code.

### Verification Process

Build against libmicrohttpd v0.9.75, v0.9.74, and v0.9.73.

### Release Notes

- Remove `http_utils::http_unordered_collection`