### PR TITLE
Using full path for includes

### DIFF
--- a/src/httpserver/basic_auth_fail_response.hpp
+++ b/src/httpserver/basic_auth_fail_response.hpp
@@ -26,7 +26,7 @@
 #define SRC_HTTPSERVER_BASIC_AUTH_FAIL_RESPONSE_HPP_
 
 #include <string>
-#include "http_utils.hpp"
+#include "httpserver/http_utils.hpp"
 #include "httpserver/string_response.hpp"
 
 struct MHD_Connection;

--- a/src/httpserver/deferred_response.hpp
+++ b/src/httpserver/deferred_response.hpp
@@ -30,7 +30,7 @@
 #include <sys/types.h>
 #include <memory>
 #include <string>
-#include "http_utils.hpp"
+#include "httpserver/http_utils.hpp"
 #include "httpserver/string_response.hpp"
 
 struct MHD_Response;

--- a/src/httpserver/digest_auth_fail_response.hpp
+++ b/src/httpserver/digest_auth_fail_response.hpp
@@ -26,7 +26,7 @@
 #define SRC_HTTPSERVER_DIGEST_AUTH_FAIL_RESPONSE_HPP_
 
 #include <string>
-#include "http_utils.hpp"
+#include "httpserver/http_utils.hpp"
 #include "httpserver/string_response.hpp"
 
 struct MHD_Connection;

--- a/src/httpserver/file_response.hpp
+++ b/src/httpserver/file_response.hpp
@@ -26,7 +26,7 @@
 #define SRC_HTTPSERVER_FILE_RESPONSE_HPP_
 
 #include <string>
-#include "http_utils.hpp"
+#include "httpserver/http_utils.hpp"
 #include "httpserver/http_response.hpp"
 
 struct MHD_Response;

--- a/src/httpserver/string_response.hpp
+++ b/src/httpserver/string_response.hpp
@@ -27,7 +27,7 @@
 
 #include <string>
 #include <utility>
-#include "http_utils.hpp"
+#include "httpserver/http_utils.hpp"
 #include "httpserver/http_response.hpp"
 
 struct MHD_Response;

--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -45,7 +45,7 @@
 #include <set>
 #include <string>
 
-#include "http_utils.hpp"
+#include "httpserver/http_utils.hpp"
 #include "httpserver/create_webserver.hpp"
 #include "httpserver/details/http_endpoint.hpp"
 

--- a/test/integ/authentication.cpp
+++ b/test/integ/authentication.cpp
@@ -32,8 +32,8 @@
 
 #include <curl/curl.h>
 
-#include "httpserver.hpp"
-#include "littletest.hpp"
+#include "./httpserver.hpp"
+#include "./littletest.hpp"
 
 #define MY_OPAQUE "11733b200778ce33060f31c9af70a870ba96ddd4"
 

--- a/test/integ/ban_system.cpp
+++ b/test/integ/ban_system.cpp
@@ -22,9 +22,9 @@
 #include <map>
 #include <string>
 
-#include "httpserver.hpp"
+#include "./httpserver.hpp"
 #include "httpserver/http_utils.hpp"
-#include "littletest.hpp"
+#include "./littletest.hpp"
 
 using std::shared_ptr;
 

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -23,9 +23,9 @@
 #include <sstream>
 #include <string>
 
-#include "httpserver.hpp"
+#include "./httpserver.hpp"
 #include "httpserver/string_utilities.hpp"
-#include "littletest.hpp"
+#include "./littletest.hpp"
 
 using std::string;
 using std::map;

--- a/test/integ/deferred.cpp
+++ b/test/integ/deferred.cpp
@@ -34,8 +34,8 @@
 #include <signal.h>
 #include <unistd.h>
 
-#include "httpserver.hpp"
-#include "littletest.hpp"
+#include "./httpserver.hpp"
+#include "./littletest.hpp"
 
 using std::shared_ptr;
 using std::string;

--- a/test/integ/nodelay.cpp
+++ b/test/integ/nodelay.cpp
@@ -22,8 +22,8 @@
 #include <map>
 #include <string>
 
-#include "httpserver.hpp"
-#include "littletest.hpp"
+#include "./httpserver.hpp"
+#include "./littletest.hpp"
 
 using std::shared_ptr;
 

--- a/test/integ/threaded.cpp
+++ b/test/integ/threaded.cpp
@@ -26,8 +26,8 @@
 #include <map>
 #include <string>
 
-#include "httpserver.hpp"
-#include "littletest.hpp"
+#include "./httpserver.hpp"
+#include "./littletest.hpp"
 
 using std::shared_ptr;
 

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -34,8 +34,8 @@
 #include <pthread.h>
 #include <unistd.h>
 
-#include "httpserver.hpp"
-#include "littletest.hpp"
+#include "./httpserver.hpp"
+#include "./littletest.hpp"
 
 using std::shared_ptr;
 

--- a/test/unit/http_endpoint_test.cpp
+++ b/test/unit/http_endpoint_test.cpp
@@ -20,7 +20,7 @@
 
 #include "httpserver/details/http_endpoint.hpp"
 
-#include "littletest.hpp"
+#include "./littletest.hpp"
 
 using httpserver::details::http_endpoint;
 using std::string;

--- a/test/unit/http_resource_test.cpp
+++ b/test/unit/http_resource_test.cpp
@@ -25,8 +25,8 @@
 #include <string>
 #include <vector>
 
-#include "httpserver.hpp"
-#include "littletest.hpp"
+#include "./httpserver.hpp"
+#include "./littletest.hpp"
 
 using std::shared_ptr;
 using std::sort;

--- a/test/unit/http_utils_test.cpp
+++ b/test/unit/http_utils_test.cpp
@@ -32,7 +32,7 @@
 
 #include <cstdio>
 
-#include "littletest.hpp"
+#include "./littletest.hpp"
 
 using std::string;
 using std::vector;

--- a/test/unit/string_utilities_test.cpp
+++ b/test/unit/string_utilities_test.cpp
@@ -22,7 +22,7 @@
 
 #include <cstdio>
 
-#include "littletest.hpp"
+#include "./littletest.hpp"
 
 using std::string;
 using std::vector;


### PR DESCRIPTION
### Identify the Bug

cppcheck introduced a new check that requires paths to be specified in local includes.

### Description of the Change

Fixed paths of all includes.

### Alternate Designs

Two alternatives: (1) ignore the check and disable it and (2) use the root path in the test Makefile.am thus allowing to pass actual paths (not relative).

(1) is sub-optimal as the check is justified for most of the codebase.
(2) would have worked but might have caused more issues of polluting the include path for tests.

### Possible Drawbacks

Tests use includes from the root-src and root-test. These are included with a prefix like './'.

This might lead to issues if those files are moved in the codebase. Given this happens only for 'httpserver.hpp' and 'littletest.hpp' the issue seems unlikely.

### Verification Process

Test execution in local and through github actions.

### Release Notes

Using full path on includes.
