### PR TITLE
Re-enable codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 codecov:
   require_ci_to_pass: yes
+  disable_default_path_fixes: true
 
 coverage:
   precision: 2


### PR DESCRIPTION
### Identify the Bug

Codecov succeeds the execution but fails to handle the coverage files once pushed.

### Description of the Change

This seems due to the library building on a separate path. The default codecov script uses the project base root as a starting point so the relative paths don't work.

This change attempts to fix the issue by disabling the standard directory rewrite used by codecov.

### Alternate Designs

We could just build in the same directory in a separate build for codecov.

### Possible Drawbacks

None

### Verification Process

Github actions will execute the codecov action as part of the build.

### Release Notes

Re-Enable automated code coverage calculation.
