### PR TITLE
Cleanup files uploaded

### DIFF
--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -256,4 +256,13 @@ std::ostream &operator<< (std::ostream &os, const http_request &r) {
     return os;
 }
 
+http_request::~http_request() {
+    for ( const auto &file_key : this->get_files() ) {
+        for ( const auto &files : file_key.second ) {
+            // C++17 has std::filesystem::remove()
+            remove(files.second.get_file_system_file_name().c_str());
+        }
+    }
+}
+
 }  // namespace httpserver

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -46,6 +46,8 @@ struct MHD_Connection;
 
 namespace httpserver {
 
+namespace details { struct modded_request; }
+
 /**
  * Class representing an abstraction for an Http Request. It is used from classes using these apis to receive information through http protocol.
 **/
@@ -254,6 +256,8 @@ class http_request {
      http_request& operator=(const http_request& b) = default;
      http_request& operator=(http_request&& b) = default;
 
+     ~http_request();
+
      std::string path;
      std::string method;
      std::map<std::string, std::string, http::arg_comparator> args;
@@ -356,6 +360,7 @@ class http_request {
      const std::map<std::string, std::string, http::header_comparator> get_headerlike_values(enum MHD_ValueKind kind) const;
 
      friend class webserver;
+     friend struct details::modded_request;
 };
 
 std::ostream &operator<< (std::ostream &os, const http_request &r);

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -197,6 +197,9 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk)
     CURLcode res = send_file_to_webserver(false, false);
     LT_ASSERT_EQ(res, 0);
 
+    ws->stop();
+    delete ws;
+
     string actual_content = resource.get_content();
     LT_CHECK_EQ(actual_content.find(FILENAME_IN_GET_CONTENT) != string::npos, true);
     LT_CHECK_EQ(actual_content.find(TEST_CONTENT) != string::npos, true);
@@ -223,9 +226,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk)
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
     LT_CHECK_EQ(file_exists(file->second.get_file_system_file_name()), false);
-
-    ws->stop();
-    delete ws;
 LT_END_AUTO_TEST(file_upload_memory_and_disk)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_via_put)
@@ -277,6 +277,9 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_additional_par
     CURLcode res = send_file_to_webserver(false, true);
     LT_ASSERT_EQ(res, 0);
 
+    ws->stop();
+    delete ws;
+
     string actual_content = resource.get_content();
     LT_CHECK_EQ(actual_content.find(FILENAME_IN_GET_CONTENT) != string::npos, true);
     LT_CHECK_EQ(actual_content.find(TEST_CONTENT) != string::npos, true);
@@ -308,9 +311,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_additional_par
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
     LT_CHECK_EQ(file_exists(file->second.get_file_system_file_name()), false);
-
-    ws->stop();
-    delete ws;
 LT_END_AUTO_TEST(file_upload_memory_and_disk_additional_params)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_two_files)
@@ -330,6 +330,9 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_two_files)
 
     CURLcode res = send_file_to_webserver(true, false);
     LT_ASSERT_EQ(res, 0);
+
+    ws->stop();
+    delete ws;
 
     string actual_content = resource.get_content();
     LT_CHECK_EQ(actual_content.find(FILENAME_IN_GET_CONTENT) != string::npos, true);
@@ -377,10 +380,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_two_files)
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
     LT_CHECK_EQ(file_exists(file->second.get_file_system_file_name()), false);
-
-
-    ws->stop();
-    delete ws;
 LT_END_AUTO_TEST(file_upload_memory_and_disk_two_files)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_disk_only)
@@ -400,6 +399,9 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_disk_only)
 
     CURLcode res = send_file_to_webserver(false, false);
     LT_ASSERT_EQ(res, 0);
+
+    ws->stop();
+    delete ws;
 
     string actual_content = resource.get_content();
     LT_CHECK_EQ(actual_content.size(), 0);
@@ -423,9 +425,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_disk_only)
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
     LT_CHECK_EQ(file_exists(file->second.get_file_system_file_name()), false);
-
-    ws->stop();
-    delete ws;
 LT_END_AUTO_TEST(file_upload_disk_only)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_incl_content)

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -59,6 +59,12 @@ static size_t TEST_CONTENT_SIZE_2 = 28;
 static const char* TEST_PARAM_KEY = "param_key";
 static const char* TEST_PARAM_VALUE = "Value of test param";
 
+static bool file_exists(const string &path) {
+    struct stat sb;
+
+    return (stat(path.c_str(), &sb) == 0);
+}
+
 static CURLcode send_file_to_webserver(bool add_second_file, bool append_parameters) {
     curl_global_init(CURL_GLOBAL_ALL);
 
@@ -216,6 +222,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk)
                                httpserver::http::http_utils::upload_filename_template;
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
+    LT_CHECK_EQ(file_exists(file->second.get_file_system_file_name()), false);
 
     ws->stop();
     delete ws;
@@ -300,6 +307,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_additional_par
                                httpserver::http::http_utils::upload_filename_template;
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
+    LT_CHECK_EQ(file_exists(file->second.get_file_system_file_name()), false);
 
     ws->stop();
     delete ws;
@@ -353,6 +361,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_two_files)
                                httpserver::http::http_utils::upload_filename_template;
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
+    LT_CHECK_EQ(file_exists(file->second.get_file_system_file_name()), false);
 
     file_key++;
     LT_CHECK_EQ(file_key->first, TEST_KEY_2);
@@ -367,6 +376,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_two_files)
                                httpserver::http::http_utils::upload_filename_template;
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
+    LT_CHECK_EQ(file_exists(file->second.get_file_system_file_name()), false);
 
 
     ws->stop();
@@ -412,6 +422,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_disk_only)
                                httpserver::http::http_utils::upload_filename_template;
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
+    LT_CHECK_EQ(file_exists(file->second.get_file_system_file_name()), false);
 
     ws->stop();
     delete ws;

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -216,7 +216,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk)
                                httpserver::http::http_utils::upload_filename_template;
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
-    unlink(file->second.get_file_system_file_name().c_str());
 
     ws->stop();
     delete ws;
@@ -301,7 +300,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_additional_par
                                httpserver::http::http_utils::upload_filename_template;
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
-    unlink(file->second.get_file_system_file_name().c_str());
 
     ws->stop();
     delete ws;
@@ -355,7 +353,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_two_files)
                                httpserver::http::http_utils::upload_filename_template;
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
-    unlink(file->second.get_file_system_file_name().c_str());
 
     file_key++;
     LT_CHECK_EQ(file_key->first, TEST_KEY_2);
@@ -370,7 +367,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_two_files)
                                httpserver::http::http_utils::upload_filename_template;
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
-    unlink(file->second.get_file_system_file_name().c_str());
 
 
     ws->stop();
@@ -416,7 +412,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_disk_only)
                                httpserver::http::http_utils::upload_filename_template;
     LT_CHECK_EQ(file->second.get_file_system_file_name().substr(0, file->second.get_file_system_file_name().size() - 6),
                 expected_filename.substr(0, expected_filename.size() - 6));
-    unlink(file->second.get_file_system_file_name().c_str());
 
     ws->stop();
     delete ws;


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* [x] Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* [x] The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/etr/libhttpserver/tree/master/.github/PULL_REQUEST_TEMPLATE.
* [x] The pull request must update the test suite to demonstrate the changed functionality.
* [x] After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/etr/libhttpserver/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

#264 

### Description of the Change

The list of files lives in the `httpserver::http_request` object.  The destructor is called after the request handler is completed, so we can assume user had done all tasks needed for this request.  Simply cleanup those files, before the files map is gone.

### Alternate Designs

_none considered_

This is the most simple approach.

### Possible Drawbacks

If the user needs those files, she should copy/move theme in the request
handler.

### Verification Process

Integration tests in my application, not public.

### Release Notes

"N/A" because follow-up to #257.
