### PR TITLE
switch callback function pointers to std::function types

### DIFF
--- a/src/httpserver/create_webserver.hpp
+++ b/src/httpserver/create_webserver.hpp
@@ -27,6 +27,7 @@
 
 #include <stdlib.h>
 #include <memory>
+#include <functional>
 #include <string>
 
 #include "httpserver/http_response.hpp"
@@ -40,10 +41,10 @@ namespace httpserver {
 class webserver;
 class http_request;
 
-typedef const std::shared_ptr<http_response>(*render_ptr)(const http_request&);
-typedef bool(*validator_ptr)(const std::string&);
-typedef void(*log_access_ptr)(const std::string&);
-typedef void(*log_error_ptr)(const std::string&);
+typedef std::function<const std::shared_ptr<http_response>(const http_request&)> render_ptr;
+typedef std::function<bool(const std::string&)> validator_ptr;
+typedef std::function<void(const std::string&)> log_access_ptr;
+typedef std::function<void(const std::string&)> log_error_ptr;
 
 class create_webserver {
  public:


### PR DESCRIPTION
**### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/etr/libhttpserver/tree/master/CONTRIBUTING.md#pull-requests.

### Issue or RFC Endorsed by Maintainers

https://github.com/etr/libhttpserver/issues/282

### Description of the Change

Change the not_found_resource (render_ptr) and other callback typedefs from function pointers to std::function objects. This allows the use of lambdas with captures, providing more flexibility to the user when creating implementations for these callbacks.

### Alternate Designs

Simple change, no other alternatives considered. 

### Possible Drawbacks

Afaict this is a drop in replacement that shouldn't affect any other part of the code. 

### Verification Process

Make check passes. Assuming there are already tests using these callbacks.

### Release Notes

`render_ptr`, `validator_ptr`, `log_access_ptr`, and `log_error_ptr` are changed to std::function types enabling the use of lambdas with captures.