### PR TITLE
Remove ineffective/unneeded const from shared_ptr return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The most basic example of creating a server and handling a requests for the path
 
     class hello_world_resource : public http_resource {
     public:
-        const std::shared_ptr<http_response> render(const http_request&) {
+        std::shared_ptr<http_response> render(const http_request&) {
             return std::shared_ptr<http_response>(new string_response("Hello, World!"));
         }
     };
@@ -219,17 +219,17 @@ In all these 3 cases libhttpserver would provide a standard HTTP response to the
 
       using namespace httpserver;
 
-      const std::shared_ptr<http_response> not_found_custom(const http_request& req) {
+      std::shared_ptr<http_response> not_found_custom(const http_request& req) {
           return std::shared_ptr<string_response>(new string_response("Not found custom", 404, "text/plain"));
       }
 
-      const std::shared_ptr<http_response> not_allowed_custom(const http_request& req) {
+      std::shared_ptr<http_response> not_allowed_custom(const http_request& req) {
           return std::shared_ptr<string_response>(new string_response("Not allowed custom", 405, "text/plain"));
       }
 
       class hello_world_resource : public http_resource {
       public:
-          const std::shared_ptr<http_response> render(const http_request&) {
+          std::shared_ptr<http_response> render(const http_request&) {
               return std::shared_ptr<http_response>(new string_response("Hello, World!"));
           }
       };
@@ -275,7 +275,7 @@ You can also check this example on [github](https://github.com/etr/libhttpserver
 
     class hello_world_resource : public http_resource {
     public:
-        const std::shared_ptr<http_response> render(const http_request&) {
+        std::shared_ptr<http_response> render(const http_request&) {
             return std::shared_ptr<http_response>(new string_response("Hello, World!"));
         }
     };
@@ -321,7 +321,7 @@ You can also check this example on [github](https://github.com/etr/libhttpserver
 
     class hello_world_resource : public http_resource {
     public:
-        const std::shared_ptr<http_response> render(const http_request&) {
+        std::shared_ptr<http_response> render(const http_request&) {
             return std::shared_ptr<http_response>(new string_response("Hello, World!"));
         }
     };
@@ -391,15 +391,15 @@ Once a webserver is created, you can manage its execution through the following 
 The `http_resource` class represents a logical collection of HTTP methods that will be associated to a URL when registered on the webserver. The class is **designed for extension** and it is where most of your code should ideally live. When the webserver matches a request against a resource (see: [resource registration](#registering-resources)), the method correspondent to the one in the request (GET, POST, etc..) (see below) is called on the resource.
 
 Given this, the `http_resource` class contains the following extensible methods (also called `handlers` or `render methods`):
-* _**const std::shared_ptr<http_response>** http_resource::render_GET(**const http_request&** req):_ Invoked on an HTTP GET request.
-* _**const std::shared_ptr<http_response>** http_resource::render_POST(**const http_request&** req):_ Invoked on an HTTP POST request.
-* _**const std::shared_ptr<http_response>** http_resource::render_PUT(**const http_request&** req):_ Invoked on an HTTP PUT request.
-* _**const std::shared_ptr<http_response>** http_resource::render_HEAD(**const http_request&** req):_ Invoked on an HTTP HEAD request.
-* _**const std::shared_ptr<http_response>** http_resource::render_DELETE(**const http_request&** req):_ Invoked on an HTTP DELETE request.
-* _**const std::shared_ptr<http_response>** http_resource::render_TRACE(**const http_request&** req):_ Invoked on an HTTP TRACE request.
-* _**const std::shared_ptr<http_response>** http_resource::render_OPTIONS(**const http_request&** req):_ Invoked on an HTTP OPTIONS request.
-* _**const std::shared_ptr<http_response>** http_resource::render_CONNECT(**const http_request&** req):_ Invoked on an HTTP CONNECT request.
-* _**const std::shared_ptr<http_response>** http_resource::render(**const http_request&** req):_ Invoked as a backup method if the matching method is not implemented. It can be used whenever you want all the invocations on a URL to activate the same behavior regardless of the HTTP method requested. The default implementation of the `render` method returns an empty response with a `404`.
+* _**std::shared_ptr<http_response>** http_resource::render_GET(**const http_request&** req):_ Invoked on an HTTP GET request.
+* _**std::shared_ptr<http_response>** http_resource::render_POST(**const http_request&** req):_ Invoked on an HTTP POST request.
+* _**std::shared_ptr<http_response>** http_resource::render_PUT(**const http_request&** req):_ Invoked on an HTTP PUT request.
+* _**std::shared_ptr<http_response>** http_resource::render_HEAD(**const http_request&** req):_ Invoked on an HTTP HEAD request.
+* _**std::shared_ptr<http_response>** http_resource::render_DELETE(**const http_request&** req):_ Invoked on an HTTP DELETE request.
+* _**std::shared_ptr<http_response>** http_resource::render_TRACE(**const http_request&** req):_ Invoked on an HTTP TRACE request.
+* _**std::shared_ptr<http_response>** http_resource::render_OPTIONS(**const http_request&** req):_ Invoked on an HTTP OPTIONS request.
+* _**std::shared_ptr<http_response>** http_resource::render_CONNECT(**const http_request&** req):_ Invoked on an HTTP CONNECT request.
+* _**std::shared_ptr<http_response>** http_resource::render(**const http_request&** req):_ Invoked as a backup method if the matching method is not implemented. It can be used whenever you want all the invocations on a URL to activate the same behavior regardless of the HTTP method requested. The default implementation of the `render` method returns an empty response with a `404`.
 
 #### Example of implementation of render methods
 ```cpp
@@ -409,11 +409,11 @@ Given this, the `http_resource` class contains the following extensible methods 
 
     class hello_world_resource : public http_resource {
     public:
-        const std::shared_ptr<http_response> render_GET(const http_request&) {
+        std::shared_ptr<http_response> render_GET(const http_request&) {
             return std::shared_ptr<http_response>(new string_response("GET: Hello, World!"));
         }
 
-        const std::shared_ptr<http_response> render(const http_request&) {
+        std::shared_ptr<http_response> render(const http_request&) {
             return std::shared_ptr<http_response>(new string_response("OTHER: Hello, World!"));
         }
     };
@@ -449,7 +449,7 @@ The base `http_resource` class has a set of methods that can be used to allow an
 
       class hello_world_resource : public http_resource {
       public:
-          const std::shared_ptr<http_response> render(const http_request&) {
+          std::shared_ptr<http_response> render(const http_request&) {
               return std::shared_ptr<http_response>(new string_response("Hello, World!"));
           }
       };
@@ -496,21 +496,21 @@ There are essentially four ways to specify an endpoint string:
 
       class hello_world_resource : public http_resource {
       public:
-          const std::shared_ptr<http_response> render(const http_request&) {
+          std::shared_ptr<http_response> render(const http_request&) {
               return std::shared_ptr<http_response>(new string_response("Hello, World!"));
           }
       };
 
       class handling_multiple_resource : public http_resource {
       public:
-          const std::shared_ptr<http_response> render(const http_request& req) {
+          std::shared_ptr<http_response> render(const http_request& req) {
               return std::shared_ptr<http_response>(new string_response("Your URL: " + req.get_path()));
           }
       };
 
       class url_args_resource : public http_resource {
       public:
-          const std::shared_ptr<http_response> render(const http_request& req) {
+          std::shared_ptr<http_response> render(const http_request& req) {
               return std::shared_ptr<http_response>(new string_response("ARGS: " + req.get_arg("arg1") + " and " + req.get_arg("arg2")));
           }
       };
@@ -596,7 +596,7 @@ Details on the `http::file_info` structure.
 
     class hello_world_resource : public http_resource {
     public:
-        const std::shared_ptr<http_response> render(const http_request& req) {
+        std::shared_ptr<http_response> render(const http_request& req) {
             return std::shared_ptr<http_response>(new string_response("Hello: " + req.get_arg("name")));
         }
     };
@@ -649,7 +649,7 @@ The `http_response` class offers an additional set of methods to "decorate" your
 
     class hello_world_resource : public http_resource {
     public:
-        const std::shared_ptr<http_response> render(const http_request&) {
+        std::shared_ptr<http_response> render(const http_request&) {
             std::shared_ptr<http_response> response = std::shared_ptr<http_response>(new string_response("Hello, World!"));
             response->with_header("MyHeader", "MyValue");
             return response;
@@ -707,7 +707,7 @@ Examples of valid IPs include:
 
     class hello_world_resource : public http_resource {
     public:
-        const std::shared_ptr<http_response> render(const http_request&) {
+        std::shared_ptr<http_response> render(const http_request&) {
             return std::shared_ptr<http_response>(new string_response("Hello, World!"));
         }
     };
@@ -750,7 +750,7 @@ Client certificate authentication uses a X.509 certificate from the client. This
 
     class user_pass_resource : public httpserver::http_resource {
     public:
-        const std::shared_ptr<http_response> render_GET(const http_request& req) {
+        std::shared_ptr<http_response> render_GET(const http_request& req) {
             if (req.get_user() != "myuser" || req.get_pass() != "mypass") {
                 return std::shared_ptr<basic_auth_fail_response>(new basic_auth_fail_response("FAIL", "test@example.com"));
             }
@@ -786,7 +786,7 @@ You can also check this example on [github](https://github.com/etr/libhttpserver
 
     class digest_resource : public httpserver::http_resource {
     public:
-        const std::shared_ptr<http_response> render_GET(const http_request& req) {
+        std::shared_ptr<http_response> render_GET(const http_request& req) {
             if (req.get_digested_user() == "") {
                 return std::shared_ptr<digest_auth_fail_response>(new digest_auth_fail_response("FAIL", "test@example.com", MY_OPAQUE, true));
             }
@@ -835,7 +835,7 @@ libhttpserver provides a set of constants to help you develop your HTTP server. 
 
     class file_response_resource : public http_resource {
     public:
-        const std::shared_ptr<http_response> render_GET(const http_request& req) {
+        std::shared_ptr<http_response> render_GET(const http_request& req) {
             return std::shared_ptr<file_response>(new file_response("test_content", 200, "text/plain"));
         }
     };
@@ -878,7 +878,7 @@ You can also check this example on [github](https://github.com/etr/libhttpserver
     
     class deferred_resource : public http_resource {
         public:
-            const std::shared_ptr<http_response> render_GET(const http_request& req) {
+            std::shared_ptr<http_response> render_GET(const http_request& req) {
                 return std::shared_ptr<deferred_response<void> >(new deferred_response<void>(test_callback, nullptr, "cycle callback response"));
             }
     };
@@ -935,7 +935,7 @@ You can also check this example on [github](https://github.com/etr/libhttpserver
     
     class deferred_resource : public http_resource {
         public:
-            const std::shared_ptr<http_response> render_GET(const http_request& req) {
+            std::shared_ptr<http_response> render_GET(const http_request& req) {
                 std::shared_ptr<std::atomic<int> > closure_data(new std::atomic<int>(counter++));
                 return std::shared_ptr<deferred_response<std::atomic<int> > >(new deferred_response<std::atomic<int> >(test_callback, closure_data, "cycle callback response"));
             }

--- a/examples/allowing_disallowing_methods.cpp
+++ b/examples/allowing_disallowing_methods.cpp
@@ -22,7 +22,7 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Hello, World!"));
      }
 };

--- a/examples/basic_authentication.cpp
+++ b/examples/basic_authentication.cpp
@@ -22,7 +22,7 @@
 
 class user_pass_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request& req) {
+     std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request& req) {
          if (req.get_user() != "myuser" || req.get_pass() != "mypass") {
              return std::shared_ptr<httpserver::basic_auth_fail_response>(new httpserver::basic_auth_fail_response("FAIL", "test@example.com"));
          }

--- a/examples/benchmark_nodelay.cpp
+++ b/examples/benchmark_nodelay.cpp
@@ -28,7 +28,7 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     explicit hello_world_resource(std::shared_ptr<httpserver::http_response>& resp):
+     explicit hello_world_resource(const std::shared_ptr<httpserver::http_response>& resp):
          resp(resp) {
      }
 

--- a/examples/benchmark_nodelay.cpp
+++ b/examples/benchmark_nodelay.cpp
@@ -28,11 +28,11 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     explicit hello_world_resource(const std::shared_ptr<httpserver::http_response>& resp):
+     explicit hello_world_resource(std::shared_ptr<httpserver::http_response>& resp):
          resp(resp) {
      }
 
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
          return resp;
      }
 

--- a/examples/benchmark_select.cpp
+++ b/examples/benchmark_select.cpp
@@ -28,7 +28,7 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     explicit hello_world_resource(std::shared_ptr<httpserver::http_response>& resp):
+     explicit hello_world_resource(const std::shared_ptr<httpserver::http_response>& resp):
          resp(resp) {
      }
 

--- a/examples/benchmark_select.cpp
+++ b/examples/benchmark_select.cpp
@@ -28,11 +28,11 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     explicit hello_world_resource(const std::shared_ptr<httpserver::http_response>& resp):
+     explicit hello_world_resource(std::shared_ptr<httpserver::http_response>& resp):
          resp(resp) {
      }
 
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
          return resp;
      }
 

--- a/examples/benchmark_threads.cpp
+++ b/examples/benchmark_threads.cpp
@@ -28,7 +28,7 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     explicit hello_world_resource(std::shared_ptr<httpserver::http_response>& resp):
+     explicit hello_world_resource(const std::shared_ptr<httpserver::http_response>& resp):
          resp(resp) {
      }
 

--- a/examples/benchmark_threads.cpp
+++ b/examples/benchmark_threads.cpp
@@ -28,11 +28,11 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     explicit hello_world_resource(const std::shared_ptr<httpserver::http_response>& resp):
+     explicit hello_world_resource(std::shared_ptr<httpserver::http_response>& resp):
          resp(resp) {
      }
 
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
          return resp;
      }
 

--- a/examples/custom_access_log.cpp
+++ b/examples/custom_access_log.cpp
@@ -28,7 +28,7 @@ void custom_access_log(const std::string& url) {
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Hello, World!"));
      }
 };

--- a/examples/custom_error.cpp
+++ b/examples/custom_error.cpp
@@ -20,17 +20,17 @@
 
 #include <httpserver.hpp>
 
-const std::shared_ptr<httpserver::http_response> not_found_custom(const httpserver::http_request&) {
+std::shared_ptr<httpserver::http_response> not_found_custom(const httpserver::http_request&) {
     return std::shared_ptr<httpserver::string_response>(new httpserver::string_response("Not found custom", 404, "text/plain"));
 }
 
-const std::shared_ptr<httpserver::http_response> not_allowed_custom(const httpserver::http_request&) {
+std::shared_ptr<httpserver::http_response> not_allowed_custom(const httpserver::http_request&) {
     return std::shared_ptr<httpserver::string_response>(new httpserver::string_response("Not allowed custom", 405, "text/plain"));
 }
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Hello, World!"));
      }
 };

--- a/examples/deferred_with_accumulator.cpp
+++ b/examples/deferred_with_accumulator.cpp
@@ -56,7 +56,7 @@ ssize_t test_callback(std::shared_ptr<std::atomic<int> > closure_data, char* buf
 
 class deferred_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
          std::shared_ptr<std::atomic<int> > closure_data(new std::atomic<int>(counter++));
          return std::shared_ptr<httpserver::deferred_response<std::atomic<int> > >(new httpserver::deferred_response<std::atomic<int> >(test_callback, closure_data, "cycle callback response"));
      }

--- a/examples/digest_authentication.cpp
+++ b/examples/digest_authentication.cpp
@@ -24,7 +24,7 @@
 
 class digest_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request& req) {
+     std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request& req) {
          if (req.get_digested_user() == "") {
              return std::shared_ptr<httpserver::digest_auth_fail_response>(new httpserver::digest_auth_fail_response("FAIL", "test@example.com", MY_OPAQUE, true));
          } else {

--- a/examples/file_upload.cpp
+++ b/examples/file_upload.cpp
@@ -23,7 +23,7 @@
 
 class file_upload_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
          std::string get_response = "<html>\n";
          get_response += "  <body>\n";
          get_response += "    <form method=\"POST\" enctype=\"multipart/form-data\">\n";
@@ -40,7 +40,7 @@ class file_upload_resource : public httpserver::http_resource {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response(get_response, 200, "text/html"));
      }
 
-     const std::shared_ptr<httpserver::http_response> render_POST(const httpserver::http_request& req) {
+     std::shared_ptr<httpserver::http_response> render_POST(const httpserver::http_request& req) {
         std::string post_response = "<html>\n";
         post_response += "<head>\n";
         post_response += "  <style>\n";

--- a/examples/handlers.cpp
+++ b/examples/handlers.cpp
@@ -22,11 +22,11 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("GET: Hello, World!"));
      }
 
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("OTHER: Hello, World!"));
      }
 };

--- a/examples/hello_with_get_arg.cpp
+++ b/examples/hello_with_get_arg.cpp
@@ -22,7 +22,7 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request& req) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request& req) {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Hello: " + req.get_arg("name")));
      }
 };

--- a/examples/hello_world.cpp
+++ b/examples/hello_world.cpp
@@ -24,13 +24,13 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&);
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&);
      void set_some_data(const std::string &s) {data = s;}
      std::string data;
 };
 
 // Using the render method you are able to catch each type of request you receive
-const std::shared_ptr<httpserver::http_response> hello_world_resource::render(const httpserver::http_request& req) {
+std::shared_ptr<httpserver::http_response> hello_world_resource::render(const httpserver::http_request& req) {
     // It is possible to store data inside the resource object that can be altered through the requests
     std::cout << "Data was: " << data << std::endl;
     std::string datapar = req.get_arg("data");

--- a/examples/minimal_deferred.cpp
+++ b/examples/minimal_deferred.cpp
@@ -37,7 +37,7 @@ ssize_t test_callback(std::shared_ptr<void> closure_data, char* buf, size_t max)
 
 class deferred_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
          return std::shared_ptr<httpserver::deferred_response<void> >(new httpserver::deferred_response<void>(test_callback, nullptr, "cycle callback response"));
      }
 };

--- a/examples/minimal_file_response.cpp
+++ b/examples/minimal_file_response.cpp
@@ -22,7 +22,7 @@
 
 class file_response_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
          return std::shared_ptr<httpserver::file_response>(new httpserver::file_response("test_content", 200, "text/plain"));
      }
 };

--- a/examples/minimal_hello_world.cpp
+++ b/examples/minimal_hello_world.cpp
@@ -22,7 +22,7 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Hello, World!"));
      }
 };

--- a/examples/minimal_https.cpp
+++ b/examples/minimal_https.cpp
@@ -22,7 +22,7 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Hello, World!"));
      }
 };

--- a/examples/minimal_ip_ban.cpp
+++ b/examples/minimal_ip_ban.cpp
@@ -22,7 +22,7 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Hello, World!"));
      }
 };

--- a/examples/service.cpp
+++ b/examples/service.cpp
@@ -33,21 +33,21 @@ class service_resource: public httpserver::http_resource {
 
      ~service_resource();
 
-     const std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request &req);
-     const std::shared_ptr<httpserver::http_response> render_PUT(const httpserver::http_request &req);
-     const std::shared_ptr<httpserver::http_response> render_POST(const httpserver::http_request &req);
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request &req);
-     const std::shared_ptr<httpserver::http_response> render_HEAD(const httpserver::http_request &req);
-     const std::shared_ptr<httpserver::http_response> render_OPTIONS(const httpserver::http_request &req);
-     const std::shared_ptr<httpserver::http_response> render_CONNECT(const httpserver::http_request &req);
-     const std::shared_ptr<httpserver::http_response> render_DELETE(const httpserver::http_request &req);
+     std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request &req);
+     std::shared_ptr<httpserver::http_response> render_PUT(const httpserver::http_request &req);
+     std::shared_ptr<httpserver::http_response> render_POST(const httpserver::http_request &req);
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request &req);
+     std::shared_ptr<httpserver::http_response> render_HEAD(const httpserver::http_request &req);
+     std::shared_ptr<httpserver::http_response> render_OPTIONS(const httpserver::http_request &req);
+     std::shared_ptr<httpserver::http_response> render_CONNECT(const httpserver::http_request &req);
+     std::shared_ptr<httpserver::http_response> render_DELETE(const httpserver::http_request &req);
 };
 
 service_resource::service_resource() { }
 
 service_resource::~service_resource() { }
 
-const std::shared_ptr<httpserver::http_response> service_resource::render_GET(const httpserver::http_request &req) {
+std::shared_ptr<httpserver::http_response> service_resource::render_GET(const httpserver::http_request &req) {
     std::cout << "service_resource::render_GET()" << std::endl;
 
     if (verbose) std::cout << req;
@@ -59,7 +59,7 @@ const std::shared_ptr<httpserver::http_response> service_resource::render_GET(co
 }
 
 
-const std::shared_ptr<httpserver::http_response> service_resource::render_PUT(const httpserver::http_request &req) {
+std::shared_ptr<httpserver::http_response> service_resource::render_PUT(const httpserver::http_request &req) {
     std::cout << "service_resource::render_PUT()" << std::endl;
 
     if (verbose) std::cout << req;
@@ -71,7 +71,7 @@ const std::shared_ptr<httpserver::http_response> service_resource::render_PUT(co
     return std::shared_ptr<httpserver::http_response>(res);
 }
 
-const std::shared_ptr<httpserver::http_response> service_resource::render_POST(const httpserver::http_request &req) {
+std::shared_ptr<httpserver::http_response> service_resource::render_POST(const httpserver::http_request &req) {
     std::cout << "service_resource::render_POST()" << std::endl;
 
     if (verbose) std::cout << req;
@@ -83,7 +83,7 @@ const std::shared_ptr<httpserver::http_response> service_resource::render_POST(c
     return std::shared_ptr<httpserver::http_response>(res);
 }
 
-const std::shared_ptr<httpserver::http_response> service_resource::render(const httpserver::http_request &req) {
+std::shared_ptr<httpserver::http_response> service_resource::render(const httpserver::http_request &req) {
     std::cout << "service_resource::render()" << std::endl;
 
     if (verbose) std::cout << req;
@@ -95,7 +95,7 @@ const std::shared_ptr<httpserver::http_response> service_resource::render(const 
     return std::shared_ptr<httpserver::http_response>(res);
 }
 
-const std::shared_ptr<httpserver::http_response> service_resource::render_HEAD(const httpserver::http_request &req) {
+std::shared_ptr<httpserver::http_response> service_resource::render_HEAD(const httpserver::http_request &req) {
     std::cout << "service_resource::render_HEAD()" << std::endl;
 
     if (verbose) std::cout << req;
@@ -107,7 +107,7 @@ const std::shared_ptr<httpserver::http_response> service_resource::render_HEAD(c
     return std::shared_ptr<httpserver::http_response>(res);
 }
 
-const std::shared_ptr<httpserver::http_response> service_resource::render_OPTIONS(const httpserver::http_request &req) {
+std::shared_ptr<httpserver::http_response> service_resource::render_OPTIONS(const httpserver::http_request &req) {
     std::cout << "service_resource::render_OPTIONS()" << std::endl;
 
     if (verbose) std::cout << req;
@@ -119,7 +119,7 @@ const std::shared_ptr<httpserver::http_response> service_resource::render_OPTION
     return std::shared_ptr<httpserver::http_response>(res);
 }
 
-const std::shared_ptr<httpserver::http_response> service_resource::render_CONNECT(const httpserver::http_request &req) {
+std::shared_ptr<httpserver::http_response> service_resource::render_CONNECT(const httpserver::http_request &req) {
     std::cout << "service_resource::render_CONNECT()" << std::endl;
 
     if (verbose) std::cout << req;
@@ -131,7 +131,7 @@ const std::shared_ptr<httpserver::http_response> service_resource::render_CONNEC
     return std::shared_ptr<httpserver::http_response>(res);
 }
 
-const std::shared_ptr<httpserver::http_response> service_resource::render_DELETE(const httpserver::http_request &req) {
+std::shared_ptr<httpserver::http_response> service_resource::render_DELETE(const httpserver::http_request &req) {
     std::cout << "service_resource::render_DELETE()" << std::endl;
 
     if (verbose) std::cout << req;

--- a/examples/setting_headers.cpp
+++ b/examples/setting_headers.cpp
@@ -22,7 +22,7 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
          std::shared_ptr<httpserver::http_response> response = std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Hello, World!"));
          response->with_header("MyHeader", "MyValue");
          return response;

--- a/examples/url_registration.cpp
+++ b/examples/url_registration.cpp
@@ -22,21 +22,21 @@
 
 class hello_world_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request&) {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Hello, World!"));
      }
 };
 
 class handling_multiple_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request& req) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request& req) {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Your URL: " + req.get_path()));
      }
 };
 
 class url_args_resource : public httpserver::http_resource {
  public:
-     const std::shared_ptr<httpserver::http_response> render(const httpserver::http_request& req) {
+     std::shared_ptr<httpserver::http_response> render(const httpserver::http_request& req) {
          return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("ARGS: " + req.get_arg("arg1") + " and " + req.get_arg("arg2")));
      }
 };

--- a/src/httpserver/create_webserver.hpp
+++ b/src/httpserver/create_webserver.hpp
@@ -41,7 +41,7 @@ namespace httpserver {
 class webserver;
 class http_request;
 
-typedef std::function<const std::shared_ptr<http_response>(const http_request&)> render_ptr;
+typedef std::function<std::shared_ptr<http_response>(const http_request&)> render_ptr;
 typedef std::function<bool(const std::string&)> validator_ptr;
 typedef std::function<void(const std::string&)> log_access_ptr;
 typedef std::function<void(const std::string&)> log_error_ptr;

--- a/src/httpserver/details/modded_request.hpp
+++ b/src/httpserver/details/modded_request.hpp
@@ -41,7 +41,7 @@ struct modded_request {
     std::string* standardized_url = nullptr;
     webserver* ws = nullptr;
 
-    const std::shared_ptr<http_response> (httpserver::http_resource::*callback)(const httpserver::http_request&);
+    std::shared_ptr<http_response> (httpserver::http_resource::*callback)(const httpserver::http_request&);
 
     http_request* dhr = nullptr;
     std::shared_ptr<http_response> dhrs;

--- a/src/httpserver/http_resource.hpp
+++ b/src/httpserver/http_resource.hpp
@@ -59,7 +59,7 @@ class http_resource {
       * @param req Request passed through http
       * @return A http_response object
      **/
-     virtual const std::shared_ptr<http_response> render(const http_request& req) {
+     virtual std::shared_ptr<http_response> render(const http_request& req) {
          return details::empty_render(req);
      }
 
@@ -68,7 +68,7 @@ class http_resource {
       * @param req Request passed through http
       * @return A http_response object
      **/
-     virtual const std::shared_ptr<http_response> render_GET(const http_request& req) {
+     virtual std::shared_ptr<http_response> render_GET(const http_request& req) {
          return render(req);
      }
 
@@ -77,7 +77,7 @@ class http_resource {
       * @param req Request passed through http
       * @return A http_response object
      **/
-     virtual const std::shared_ptr<http_response> render_POST(const http_request& req) {
+     virtual std::shared_ptr<http_response> render_POST(const http_request& req) {
          return render(req);
      }
 
@@ -86,7 +86,7 @@ class http_resource {
       * @param req Request passed through http
       * @return A http_response object
      **/
-     virtual const std::shared_ptr<http_response> render_PUT(const http_request& req) {
+     virtual std::shared_ptr<http_response> render_PUT(const http_request& req) {
          return render(req);
      }
 
@@ -95,7 +95,7 @@ class http_resource {
       * @param req Request passed through http
       * @return A http_response object
      **/
-     virtual const std::shared_ptr<http_response> render_HEAD(const http_request& req) {
+     virtual std::shared_ptr<http_response> render_HEAD(const http_request& req) {
          return render(req);
      }
 
@@ -104,7 +104,7 @@ class http_resource {
       * @param req Request passed through http
       * @return A http_response object
      **/
-     virtual const std::shared_ptr<http_response> render_DELETE(const http_request& req) {
+     virtual std::shared_ptr<http_response> render_DELETE(const http_request& req) {
          return render(req);
      }
 
@@ -113,7 +113,7 @@ class http_resource {
       * @param req Request passed through http
       * @return A http_response object
      **/
-     virtual const std::shared_ptr<http_response> render_TRACE(const http_request& req) {
+     virtual std::shared_ptr<http_response> render_TRACE(const http_request& req) {
          return render(req);
      }
 
@@ -122,7 +122,7 @@ class http_resource {
       * @param req Request passed through http
       * @return A http_response object
      **/
-     virtual const std::shared_ptr<http_response> render_OPTIONS(const http_request& req) {
+     virtual std::shared_ptr<http_response> render_OPTIONS(const http_request& req) {
          return render(req);
      }
 
@@ -131,7 +131,7 @@ class http_resource {
       * @param req Request passed through http
       * @return A http_response object
      **/
-     virtual const std::shared_ptr<http_response> render_PATCH(const http_request& req) {
+     virtual std::shared_ptr<http_response> render_PATCH(const http_request& req) {
          return render(req);
      }
 
@@ -140,7 +140,7 @@ class http_resource {
       * @param req Request passed through http
       * @return A http_response object
      **/
-     virtual const std::shared_ptr<http_response> render_CONNECT(const http_request& req) {
+     virtual std::shared_ptr<http_response> render_CONNECT(const http_request& req) {
          return render(req);
      }
 

--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -182,9 +182,9 @@ class webserver {
 
      struct MHD_Daemon* daemon;
 
-     const std::shared_ptr<http_response> method_not_allowed_page(details::modded_request* mr) const;
-     const std::shared_ptr<http_response> internal_error_page(details::modded_request* mr, bool force_our = false) const;
-     const std::shared_ptr<http_response> not_found_page(details::modded_request* mr) const;
+     std::shared_ptr<http_response> method_not_allowed_page(details::modded_request* mr) const;
+     std::shared_ptr<http_response> internal_error_page(details::modded_request* mr, bool force_our = false) const;
+     std::shared_ptr<http_response> not_found_page(details::modded_request* mr) const;
 
      static void request_completed(void *cls,
              struct MHD_Connection *connection, void **con_cls,

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -526,7 +526,7 @@ void webserver::upgrade_handler(void *cls, struct MHD_Connection* connection, vo
     std::ignore = upgrade_socket;
 }
 
-const std::shared_ptr<http_response> webserver::not_found_page(details::modded_request* mr) const {
+std::shared_ptr<http_response> webserver::not_found_page(details::modded_request* mr) const {
     if (not_found_resource != nullptr) {
         return not_found_resource(*mr->dhr);
     } else {
@@ -534,7 +534,7 @@ const std::shared_ptr<http_response> webserver::not_found_page(details::modded_r
     }
 }
 
-const std::shared_ptr<http_response> webserver::method_not_allowed_page(details::modded_request* mr) const {
+std::shared_ptr<http_response> webserver::method_not_allowed_page(details::modded_request* mr) const {
     if (method_not_allowed_resource != nullptr) {
         return method_not_allowed_resource(*mr->dhr);
     } else {
@@ -542,7 +542,7 @@ const std::shared_ptr<http_response> webserver::method_not_allowed_page(details:
     }
 }
 
-const std::shared_ptr<http_response> webserver::internal_error_page(details::modded_request* mr, bool force_our) const {
+std::shared_ptr<http_response> webserver::internal_error_page(details::modded_request* mr, bool force_our) const {
     if (internal_error_resource != nullptr && !force_our) {
         return internal_error_resource(*mr->dhr);
     } else {

--- a/test/integ/authentication.cpp
+++ b/test/integ/authentication.cpp
@@ -54,7 +54,7 @@ size_t writefunc(void *ptr, size_t size, size_t nmemb, std::string *s) {
 
 class user_pass_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request& req) {
+     shared_ptr<http_response> render_GET(const http_request& req) {
          if (req.get_user() != "myuser" || req.get_pass() != "mypass") {
              return shared_ptr<basic_auth_fail_response>(new basic_auth_fail_response("FAIL", "examplerealm"));
          }
@@ -64,7 +64,7 @@ class user_pass_resource : public http_resource {
 
 class digest_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request& req) {
+     shared_ptr<http_response> render_GET(const http_request& req) {
          if (req.get_digested_user() == "") {
              return shared_ptr<digest_auth_fail_response>(new digest_auth_fail_response("FAIL", "examplerealm", MY_OPAQUE, true));
          } else {

--- a/test/integ/ban_system.cpp
+++ b/test/integ/ban_system.cpp
@@ -43,7 +43,7 @@ size_t writefunc(void *ptr, size_t size, size_t nmemb, std::string *s) {
 
 class ok_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
 };

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -59,31 +59,31 @@ size_t headerfunc(void *ptr, size_t size, size_t nmemb, map<string, string>* ss)
 
 class simple_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
-     const shared_ptr<http_response> render_POST(const http_request& req) {
+     shared_ptr<http_response> render_POST(const http_request& req) {
          return shared_ptr<string_response>(new string_response(req.get_arg("arg1")+req.get_arg("arg2"), 200, "text/plain"));
      }
 };
 
 class args_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request& req) {
+     shared_ptr<http_response> render_GET(const http_request& req) {
          return shared_ptr<string_response>(new string_response(req.get_arg("arg") + req.get_arg("arg2"), 200, "text/plain"));
      }
 };
 
 class long_content_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<string_response>(new string_response(lorem_ipsum, 200, "text/plain"));
      }
 };
 
 class header_set_test_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          shared_ptr<string_response> hrb(new string_response("OK", 200, "text/plain"));
          hrb->with_header("KEY", "VALUE");
          return hrb;
@@ -92,7 +92,7 @@ class header_set_test_resource : public http_resource {
 
 class cookie_set_test_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          shared_ptr<string_response> hrb(new string_response("OK", 200, "text/plain"));
          hrb->with_cookie("MyCookie", "CookieValue");
          return hrb;
@@ -101,35 +101,35 @@ class cookie_set_test_resource : public http_resource {
 
 class cookie_reading_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request& req) {
+     shared_ptr<http_response> render_GET(const http_request& req) {
          return shared_ptr<string_response>(new string_response(req.get_cookie("name"), 200, "text/plain"));
      }
 };
 
 class header_reading_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request& req) {
+     shared_ptr<http_response> render_GET(const http_request& req) {
          return shared_ptr<string_response>(new string_response(req.get_header("MyHeader"), 200, "text/plain"));
      }
 };
 
 class full_args_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request& req) {
+     shared_ptr<http_response> render_GET(const http_request& req) {
          return shared_ptr<string_response>(new string_response(req.get_args().at("arg"), 200, "text/plain"));
      }
 };
 
 class querystring_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request& req) {
+     shared_ptr<http_response> render_GET(const http_request& req) {
          return shared_ptr<string_response>(new string_response(req.get_querystring(), 200, "text/plain"));
      }
 };
 
 class path_pieces_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request& req) {
+     shared_ptr<http_response> render_GET(const http_request& req) {
          stringstream ss;
          for (unsigned int i = 0; i < req.get_path_pieces().size(); i++) {
              ss << req.get_path_piece(i) << ",";
@@ -140,111 +140,111 @@ class path_pieces_resource : public http_resource {
 
 class complete_test_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
 
-     const shared_ptr<http_response> render_POST(const http_request&) {
+     shared_ptr<http_response> render_POST(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
 
-     const shared_ptr<http_response> render_PUT(const http_request&) {
+     shared_ptr<http_response> render_PUT(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
 
-     const shared_ptr<http_response> render_DELETE(const http_request&) {
+     shared_ptr<http_response> render_DELETE(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
 
-     const shared_ptr<http_response> render_CONNECT(const http_request&) {
+     shared_ptr<http_response> render_CONNECT(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
 
-     const shared_ptr<http_response> render_PATCH(const http_request&) {
+     shared_ptr<http_response> render_PATCH(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
 };
 
 class only_render_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render(const http_request&) {
+     shared_ptr<http_response> render(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
 };
 
 class ok_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
 };
 
 class nok_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<string_response>(new string_response("NOK", 200, "text/plain"));
      }
 };
 
 class no_response_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<http_response>(new http_response());
      }
 };
 
 class empty_response_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<http_response>(nullptr);
      }
 };
 
 class file_response_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<file_response>(new file_response("test_content", 200, "text/plain"));
      }
 };
 
 class file_response_resource_empty : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<file_response>(new file_response("test_content_empty", 200, "text/plain"));
      }
 };
 
 class file_response_resource_default_content_type : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<file_response>(new file_response("test_content", 200));
      }
 };
 
 class file_response_resource_missing : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<file_response>(new file_response("missing", 200));
      }
 };
 
 class file_response_resource_dir : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<file_response>(new file_response("integ", 200));
      }
 };
 
 class exception_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          throw std::domain_error("invalid");
      }
 };
 
 class error_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          throw "invalid";
      }
 };
@@ -255,7 +255,7 @@ class print_request_resource : public http_resource {
          this->ss = ss;
      }
 
-     const shared_ptr<http_response> render_GET(const http_request& req) {
+     shared_ptr<http_response> render_GET(const http_request& req) {
          (*ss) << req;
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
@@ -270,7 +270,7 @@ class print_response_resource : public http_resource {
          this->ss = ss;
      }
 
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          shared_ptr<string_response> hresp(new string_response("OK", 200, "text/plain"));
 
          hresp->with_header("MyResponseHeader", "MyResponseHeaderValue");

--- a/test/integ/deferred.cpp
+++ b/test/integ/deferred.cpp
@@ -87,14 +87,14 @@ ssize_t test_callback_with_data(shared_ptr<test_data> closure_data, char* buf, s
 
 class deferred_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<deferred_response<void>>(new deferred_response<void>(test_callback, nullptr, "cycle callback response"));
      }
 };
 
 class deferred_resource_with_data : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          shared_ptr<test_data> internal_info(new test_data);
          internal_info->value = 42;
          return shared_ptr<deferred_response<test_data>>(new deferred_response<test_data>(test_callback_with_data, internal_info, "cycle callback response"));

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -137,7 +137,7 @@ static bool send_file_via_put() {
 
 class print_file_upload_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_POST(const http_request& req) {
+     shared_ptr<http_response> render_POST(const http_request& req) {
          content = req.get_content();
          args = req.get_args();
          files = req.get_files();
@@ -145,7 +145,7 @@ class print_file_upload_resource : public http_resource {
          return hresp;
      }
 
-     const shared_ptr<http_response> render_PUT(const http_request& req) {
+     shared_ptr<http_response> render_PUT(const http_request& req) {
          content = req.get_content();
          args = req.get_args();
          files = req.get_files();

--- a/test/integ/nodelay.cpp
+++ b/test/integ/nodelay.cpp
@@ -37,7 +37,7 @@ using httpserver::create_webserver;
 
 class ok_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
 };

--- a/test/integ/threaded.cpp
+++ b/test/integ/threaded.cpp
@@ -40,7 +40,7 @@ using httpserver::create_webserver;
 
 class ok_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
      }
 };

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -46,16 +46,16 @@ size_t writefunc(void *ptr, size_t size, size_t nmemb, std::string *s) {
 
 class ok_resource : public httpserver::http_resource {
  public:
-     const shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
+     shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
          return shared_ptr<httpserver::string_response>(new httpserver::string_response("OK", 200, "text/plain"));
      }
 };
 
-const shared_ptr<httpserver::http_response> not_found_custom(const httpserver::http_request&) {
+shared_ptr<httpserver::http_response> not_found_custom(const httpserver::http_request&) {
     return shared_ptr<httpserver::string_response>(new httpserver::string_response("Not found custom", 404, "text/plain"));
 }
 
-const shared_ptr<httpserver::http_response> not_allowed_custom(const httpserver::http_request&) {
+shared_ptr<httpserver::http_response> not_allowed_custom(const httpserver::http_request&) {
     return shared_ptr<httpserver::string_response>(new httpserver::string_response("Not allowed custom", 405, "text/plain"));
 }
 

--- a/test/unit/http_resource_test.cpp
+++ b/test/unit/http_resource_test.cpp
@@ -40,7 +40,7 @@ using httpserver::string_response;
 
 class simple_resource : public http_resource {
  public:
-     const shared_ptr<http_response> render_GET(const http_request&) {
+     shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<string_response>(new string_response("OK"));
      }
 };


### PR DESCRIPTION
### Identify the Bug

https://github.com/etr/libhttpserver/issues/284

### Description of the Change

Replace all instances of `const shared_ptr<http_response>` with `shared_ptr<http_response>`

### Alternate Designs

There is no alternate design 

### Possible Drawbacks

I don't believe there are any. 

### Verification Process

All tests pass. Everything compiles fine. clang-tidy no longer reports the issue in a code base that uses this return type.

### Release Notes

Remove ineffective/unneeded const from std::shared_ptr <http_response> return types.
