### PR TITLE
Add cstring import to examples using memset

### DIFF
--- a/examples/deferred_with_accumulator.cpp
+++ b/examples/deferred_with_accumulator.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <atomic>
+#include <cstring>
 // cpplint errors on chrono and thread because they are replaced (in Chromium) by other google libraries.
 // This is not an issue here.
 #include <chrono> // NOLINT [build/c++11]

--- a/examples/minimal_deferred.cpp
+++ b/examples/minimal_deferred.cpp
@@ -18,6 +18,7 @@
      USA
 */
 
+#include <cstring>
 #include <httpserver.hpp>
 
 static int counter = 0;

--- a/test/integ/deferred.cpp
+++ b/test/integ/deferred.cpp
@@ -30,6 +30,7 @@
 #include <sys/socket.h>
 #endif
 
+#include <cstring>
 #include <curl/curl.h>
 #include <signal.h>
 #include <unistd.h>


### PR DESCRIPTION
### Identify the Bug

Build started failing because memset not found (on latest ubuntu version).

### Description of the Change

Explicitly import memset by including <cstring> where appropriate.

### Alternate Designs

None considered

### Possible Drawbacks

None

### Verification Process

Github actions running build + tests.

### Release Notes

Fix issue with missing memset while building examples.
