### PR TITLE
Fix-build-issues-clang-13

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -442,6 +442,11 @@ jobs:
           ../configure --disable-fastopen;
         fi
 
+    - name: Print config.log
+      run: |
+        cd build ;
+        cat config.log ;
+
     # Make or run iwyu. If running iwyu, check for the result code to be 2 (IWYU always returns an error code, if it is 2, no corrections are necessary).
     - name: Make or run IWYU
       run: |

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -63,7 +63,7 @@ jobs:
             debug: debug
             coverage: nocoverage
           - test-group: extra
-            os: ubuntu-20.04
+            os: ubuntu-18.04
             os-type: ubuntu
             build-type: msan
             compiler-family: clang

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -414,7 +414,7 @@ jobs:
       run: |
         # Set memory check flags. They need to stay in step as env variables don't propagate across steps.
         if [ "$BUILD_TYPE" = "asan" ]; then export CFLAGS='-fsanitize=address'; export CXXLAGS='-fsanitize=address'; export LDFLAGS='-fsanitize=address'; fi
-        if [ "$BUILD_TYPE" = "msan" ]; then export CFLAGS='-fsanitize=memory'; export CXXLAGS='-fsanitize=memory'; export LDFLAGS='-fsanitize=memory'; fi
+        if [ "$BUILD_TYPE" = "msan" ]; then export CFLAGS='-fsanitize=memory -fsanitize-ignorelist=${top_builddir}/../msan_ignorelist.txt'; export CXXLAGS='-fsanitize=memory -fsanitize-ignorelist=${top_builddir}/../msan_ignorelist.txt'; export LDFLAGS='-fsanitize=memory -fsanitize-ignorelist=${top_builddir}/../msan_ignorelist.txt'; fi
         if [ "$BUILD_TYPE" = "lsan" ]; then export CFLAGS='-fsanitize=leak'; export CXXLAGS='-fsanitize=leak'; export LDFLAGS='-fsanitize=leak'; fi
         if [ "$BUILD_TYPE" = "tsan" ]; then export CFLAGS='-fsanitize=thread'; export CXXLAGS='-fsanitize=thread'; export LDFLAGS='-fsanitize=thread'; fi
         if [ "$BUILD_TYPE" = "ubsan" ]; then export export CFLAGS='-fsanitize=undefined'; export CXXLAGS='-fsanitize=undefined'; export LDFLAGS='-fsanitize=undefined'; fi

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -63,12 +63,12 @@ jobs:
             debug: debug
             coverage: nocoverage
           - test-group: extra
-            os: ubuntu-latest
+            os: ubuntu-20.04
             os-type: ubuntu
             build-type: msan
             compiler-family: clang
-            c-compiler: clang-13
-            cc-compiler: clang++-13
+            c-compiler: clang-6
+            cc-compiler: clang++-6
             debug: debug
             coverage: nocoverage
           - test-group: extra
@@ -414,7 +414,7 @@ jobs:
       run: |
         # Set memory check flags. They need to stay in step as env variables don't propagate across steps.
         if [ "$BUILD_TYPE" = "asan" ]; then export CFLAGS='-fsanitize=address'; export CXXLAGS='-fsanitize=address'; export LDFLAGS='-fsanitize=address'; fi
-        if [ "$BUILD_TYPE" = "msan" ]; then export CFLAGS='-fsanitize=memory -fsanitize-ignorelist=${top_builddir}/../msan_ignorelist.txt'; export CXXLAGS='-fsanitize=memory -fsanitize-ignorelist=${top_builddir}/../msan_ignorelist.txt'; export LDFLAGS='-fsanitize=memory -fsanitize-ignorelist=${top_builddir}/../msan_ignorelist.txt'; fi
+        if [ "$BUILD_TYPE" = "msan" ]; then export CFLAGS='-fsanitize=memory'; export CXXLAGS='-fsanitize=memory'; export LDFLAGS='-fsanitize=memory'; fi
         if [ "$BUILD_TYPE" = "lsan" ]; then export CFLAGS='-fsanitize=leak'; export CXXLAGS='-fsanitize=leak'; export LDFLAGS='-fsanitize=leak'; fi
         if [ "$BUILD_TYPE" = "tsan" ]; then export CFLAGS='-fsanitize=thread'; export CXXLAGS='-fsanitize=thread'; export LDFLAGS='-fsanitize=thread'; fi
         if [ "$BUILD_TYPE" = "ubsan" ]; then export export CFLAGS='-fsanitize=undefined'; export CXXLAGS='-fsanitize=undefined'; export LDFLAGS='-fsanitize=undefined'; fi

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -67,8 +67,8 @@ jobs:
             os-type: ubuntu
             build-type: msan
             compiler-family: clang
-            c-compiler: clang-6
-            cc-compiler: clang++-6
+            c-compiler: clang-6.0
+            cc-compiler: clang++-6.0
             debug: debug
             coverage: nocoverage
           - test-group: extra

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -446,6 +446,7 @@ jobs:
       run: |
         cd build ;
         cat config.log ;
+      if: ${{ failure() }}
 
     # Make or run iwyu. If running iwyu, check for the result code to be 2 (IWYU always returns an error code, if it is 2, no corrections are necessary).
     - name: Make or run IWYU

--- a/msan_ignorelist.txt
+++ b/msan_ignorelist.txt
@@ -1,0 +1,3 @@
+fun:__interceptor_strlen
+fun:__interceptor_fopen64
+fun:__interceptor_memcmp

--- a/test/integ/deferred.cpp
+++ b/test/integ/deferred.cpp
@@ -30,10 +30,11 @@
 #include <sys/socket.h>
 #endif
 
-#include <cstring>
 #include <curl/curl.h>
 #include <signal.h>
 #include <unistd.h>
+
+#include <cstring>
 
 #include "./httpserver.hpp"
 #include "./littletest.hpp"


### PR DESCRIPTION
### Identify the Bug

With the update of github actions to the latest version of ubuntu, we moved the library to build on clang-13 and gcc-10. Both have added additional warnings that this PR attempts to fix.

1. The order in which libraries are included in deferred.cpp is wrong and mixes C includes with C++ includes.
2. msan is mistakenly finding issues in system libraries.

### Description of the Change

Re-order the includes in deferred.cpp.
Force msan to ignore functions from system libraries.

### Alternate Designs

None.

### Possible Drawbacks

None.

### Verification Process

Build process which includes testing.
