### PR TITLE
fix #292 change get_args to return mutliple values per key

### DIFF
--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -525,11 +525,35 @@ void dump_map(std::ostream& os, const std::string& prefix, const map_t& map) {
 }
 
 void dump_header_map(std::ostream& os, const std::string& prefix, const http::header_view_map &map) {
-    dump_map<http::header_view_map>(os, prefix, map);
+    auto it = map.begin();
+    auto end = map.end();
+
+    if (map.size()) {
+        os << "    " << prefix << " [";
+        for (; it != end; ++it) {
+            os << (*it).first << ":\"" << (*it).second << "\" ";
+        }
+        os << "]" << std::endl;
+    }
 }
 
 void dump_arg_map(std::ostream& os, const std::string& prefix, const http::arg_view_map &map) {
-    dump_map<http::arg_view_map>(os, prefix, map);
+    auto it = map.begin();
+    auto end = map.end();
+
+    if (map.size()) {
+        os << "    " << prefix << " [";
+        for (; it != end; ++it) {
+            os << (*it).first << ":[";
+            std::string delim = "";
+            for (const auto & v : it->second) {
+                os << delim << "\"" << v << "\"";
+                delim = ", ";
+            }
+            os << "] ";
+        }
+        os << "]" << std::endl;
+    }
 }
 
 size_t base_unescaper(std::string* s, unescaper_ptr unescaper) {

--- a/src/httpserver/http_utils.hpp
+++ b/src/httpserver/http_utils.hpp
@@ -318,8 +318,8 @@ class arg_comparator {
 
 using header_map = std::map<std::string, std::string, http::header_comparator>;
 using header_view_map = std::map<std::string_view, std::string_view, http::header_comparator>;
-using arg_map = std::map<std::string, std::string, http::arg_comparator>;
-using arg_view_map = std::map<std::string_view, std::string_view, http::arg_comparator>;
+using arg_map = std::map<std::string, std::vector<std::string>, http::arg_comparator>;
+using arg_view_map = std::map<std::string_view, std::vector<std::string_view>, http::arg_comparator>;
 
 struct ip_representation {
     http_utils::IP_version_T ip_version;

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -116,7 +116,10 @@ class header_reading_resource : public http_resource {
 class full_args_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request& req) {
-         return shared_ptr<string_response>(new string_response(std::string(req.get_args().at("arg")), 200, "text/plain"));
+         const auto args = req.get_args();
+         const auto arg = args.at("arg");
+         const auto resp = std::string(arg[0]) + std::string(arg[1]);
+         return shared_ptr<string_response>(new string_response(resp, 200, "text/plain"));
      }
 };
 
@@ -772,13 +775,13 @@ LT_BEGIN_AUTO_TEST(basic_suite, full_arguments_processing)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/this/captures/args/passed/in/the/querystring?arg=argument");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/this/captures/args/passed/in/the/querystring?arg=argument&arg=another");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
     res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
-    LT_CHECK_EQ(s, "argument");
+    LT_CHECK_EQ(s, "argumentanother");
     curl_easy_cleanup(curl);
 LT_END_AUTO_TEST(full_arguments_processing)
 

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -144,7 +144,7 @@ class print_file_upload_resource : public http_resource {
          auto args_view = req.get_args();
          // req may go out of scope, so we need to copy the values.
          for (auto const& item : args_view) {
-            args[std::string(item.first)] = std::string(item.second);
+            args[std::string(item.first)] = {std::string(item.second.front())};
          }
          files = req.get_files();
          shared_ptr<string_response> hresp(new string_response("OK", 201, "text/plain"));
@@ -156,7 +156,7 @@ class print_file_upload_resource : public http_resource {
          auto args_view = req.get_args();
          // req may go out of scope, so we need to copy the values.
          for (auto const& item : args_view) {
-            args[std::string(item.first)] = std::string(item.second);
+            args[std::string(item.first)] = {std::string(item.second.front())};
          }
          files = req.get_files();
          shared_ptr<string_response> hresp(new string_response("OK", 200, "text/plain"));
@@ -218,7 +218,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk)
     LT_CHECK_EQ(args.size(), 1);
     auto arg = args.begin();
     LT_CHECK_EQ(arg->first, TEST_KEY);
-    LT_CHECK_EQ(arg->second, TEST_CONTENT);
+    LT_CHECK_EQ(arg->second.front(), TEST_CONTENT);
 
     map<string, map<string, httpserver::http::file_info>> files = resource.get_files();
     LT_CHECK_EQ(files.size(), 1);
@@ -300,10 +300,10 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_additional_par
     LT_CHECK_EQ(args.size(), 2);
     auto arg = args.begin();
     LT_CHECK_EQ(arg->first, TEST_KEY);
-    LT_CHECK_EQ(arg->second, TEST_CONTENT);
+    LT_CHECK_EQ(arg->second.front(), TEST_CONTENT);
     arg++;
     LT_CHECK_EQ(arg->first, TEST_PARAM_KEY);
-    LT_CHECK_EQ(arg->second, TEST_PARAM_VALUE);
+    LT_CHECK_EQ(arg->second.front(), TEST_PARAM_VALUE);
 
     map<string, map<string, httpserver::http::file_info>> files = resource.get_files();
     LT_CHECK_EQ(files.size(), 1);
@@ -354,10 +354,10 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_two_files)
     LT_CHECK_EQ(args.size(), 2);
     auto arg = args.begin();
     LT_CHECK_EQ(arg->first, TEST_KEY);
-    LT_CHECK_EQ(arg->second, TEST_CONTENT);
+    LT_CHECK_EQ(arg->second.front(), TEST_CONTENT);
     arg++;
     LT_CHECK_EQ(arg->first, TEST_KEY_2);
-    LT_CHECK_EQ(arg->second, TEST_CONTENT_2);
+    LT_CHECK_EQ(arg->second.front(), TEST_CONTENT_2);
 
     map<string, map<string, httpserver::http::file_info>> files = resource.get_files();
     LT_CHECK_EQ(files.size(), 2);
@@ -461,7 +461,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_incl_content)
     LT_CHECK_EQ(args.size(), 1);
     auto arg = args.begin();
     LT_CHECK_EQ(arg->first, TEST_KEY);
-    LT_CHECK_EQ(arg->second, TEST_CONTENT);
+    LT_CHECK_EQ(arg->second.front(), TEST_CONTENT);
 
     map<string, map<string, httpserver::http::file_info>> files = resource.get_files();
     LT_CHECK_EQ(resource.get_files().size(), 0);
@@ -493,7 +493,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_excl_content)
     LT_CHECK_EQ(args.size(), 1);
     auto arg = args.begin();
     LT_CHECK_EQ(arg->first, TEST_KEY);
-    LT_CHECK_EQ(arg->second, TEST_CONTENT);
+    LT_CHECK_EQ(arg->second.front(), TEST_CONTENT);
 
     map<string, map<string, httpserver::http::file_info>> files = resource.get_files();
     LT_CHECK_EQ(files.size(), 0);

--- a/test/unit/http_utils_test.cpp
+++ b/test/unit/http_utils_test.cpp
@@ -618,25 +618,25 @@ LT_BEGIN_AUTO_TEST(http_utils_suite, dump_header_map_no_prefix)
 LT_END_AUTO_TEST(dump_header_map_no_prefix)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, dump_arg_map)
-    std::map<std::string_view, std::string_view, httpserver::http::arg_comparator> arg_map;
-    arg_map["ARG_ONE"] = "VALUE_ONE";
-    arg_map["ARG_TWO"] = "VALUE_TWO";
-    arg_map["ARG_THREE"] = "VALUE_THREE";
+    std::map<std::string_view, std::vector<std::string_view>, httpserver::http::arg_comparator> arg_map;
+    arg_map["ARG_ONE"] = {"VALUE_ONE", "VALUE_ONE_2"};
+    arg_map["ARG_TWO"] = {"VALUE_TWO"};
+    arg_map["ARG_THREE"] = {"VALUE_THREE"};
 
     std::stringstream ss;
     httpserver::http::dump_arg_map(ss, "prefix", arg_map);
-    LT_CHECK_EQ(ss.str(), "    prefix [ARG_ONE:\"VALUE_ONE\" ARG_TWO:\"VALUE_TWO\" ARG_THREE:\"VALUE_THREE\" ]\n");
+    LT_CHECK_EQ(ss.str(), "    prefix [ARG_ONE:[\"VALUE_ONE\", \"VALUE_ONE_2\"] ARG_TWO:[\"VALUE_TWO\"] ARG_THREE:[\"VALUE_THREE\"] ]\n");
 LT_END_AUTO_TEST(dump_arg_map)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, dump_arg_map_no_prefix)
-    std::map<std::string_view, std::string_view, httpserver::http::arg_comparator> arg_map;
-    arg_map["ARG_ONE"] = "VALUE_ONE";
-    arg_map["ARG_TWO"] = "VALUE_TWO";
-    arg_map["ARG_THREE"] = "VALUE_THREE";
+    std::map<std::string_view, std::vector<std::string_view>, httpserver::http::arg_comparator> arg_map;
+    arg_map["ARG_ONE"] = {"VALUE_ONE", "VALUE_ONE_2"};
+    arg_map["ARG_TWO"] = {"VALUE_TWO"};
+    arg_map["ARG_THREE"] = {"VALUE_THREE"};
 
     std::stringstream ss;
     httpserver::http::dump_arg_map(ss, "", arg_map);
-    LT_CHECK_EQ(ss.str(), "     [ARG_ONE:\"VALUE_ONE\" ARG_TWO:\"VALUE_TWO\" ARG_THREE:\"VALUE_THREE\" ]\n");
+    LT_CHECK_EQ(ss.str(), "     [ARG_ONE:[\"VALUE_ONE\", \"VALUE_ONE_2\"] ARG_TWO:[\"VALUE_TWO\"] ARG_THREE:[\"VALUE_THREE\"] ]\n");
 LT_END_AUTO_TEST(dump_arg_map_no_prefix)
 
 LT_BEGIN_AUTO_TEST_ENV()


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/etr/libhttpserver/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/etr/libhttpserver/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

https://github.com/etr/libhttpserver/issues/292

### Description of the Change

Change arg_map and arg_view_map to `std::map<std::string, std::vector<std::string>>` etc, so that multiple values per key can be returned.

Update an appropriate test case to check that the behavior is correct.

### Alternate Designs

No alternate designs

### Possible Drawbacks

Small change to user facing API.

### Verification Process

Tests were updated to check that new code is correct.

### Release Notes

 - Fixed a bug where http_request::get_args() only returned the last value for a given argument key. It now returns all values associated with a given key.