### PR TITLE
Add verification build on gcc-11

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -135,6 +135,15 @@ jobs:
             debug: nodebug
             coverage: nocoverage
           - test-group: extra
+            os: ubuntu-latest
+            os-type: ubuntu
+            build-type: none
+            compiler-family: gcc
+            c-compiler: gcc-11
+            cc-compiler: g++-11
+            debug: nodebug
+            coverage: nocoverage
+          - test-group: extra
             os: ubuntu-18.04
             os-type: ubuntu
             build-type: none


### PR DESCRIPTION
### Description of the Change

Adds verification build on gcc-11

### Alternate Designs

N/D

### Possible Drawbacks

It might not build on gcc-11, but that's something we should discover early.

### Verification Process

Executes new tests at push time on the codebase

### Release Notes

Adds verification build on gcc-11