### PR TITLE
Make `httpserver::error_log` consume and apply `va_list`.

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -436,15 +436,16 @@ void error_log(void* cls, const char* fmt, va_list ap) {
 
     va_list va;
     va_copy(va, ap);
-    size_t r = vsnprintf(&*msg.begin(), msg.size(), fmt, va);
+
+    size_t r = vsnprintf(&*msg.begin(), msg.size(), fmt, ap);
     va_end(ap);
 
     if (msg.size() < r) {
       msg.resize(r);
       va_copy(va, ap);
       r = vsnprintf(&*msg.begin(), msg.size(), fmt, va);
-      va_end(ap);
     }
+    va_end(va);
     msg.resize(r);
 
     if (dws->log_error != nullptr) dws->log_error(msg);

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -435,14 +435,13 @@ void error_log(void* cls, const char* fmt, va_list ap) {
     msg.resize(80);  // Asssume one line will be enought most of the time.
 
     va_list va;
-    va_copy(va, ap);
+    va_copy(va, ap);  // Stash a copy in case we need to try again.
 
     size_t r = vsnprintf(&*msg.begin(), msg.size(), fmt, ap);
     va_end(ap);
 
     if (msg.size() < r) {
       msg.resize(r);
-      va_copy(va, ap);
       r = vsnprintf(&*msg.begin(), msg.size(), fmt, va);
     }
     va_end(va);

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -429,11 +429,25 @@ void* uri_log(void* cls, const char* uri) {
 }
 
 void error_log(void* cls, const char* fmt, va_list ap) {
-    // Parameter needed to respect MHD interface, but not needed here.
-    std::ignore = ap;
-
     webserver* dws = static_cast<webserver*>(cls);
-    if (dws->log_error != nullptr) dws->log_error(fmt);
+
+    std::string msg;
+    msg.resize(80);  // Asssume one line will be enought most of the time.
+
+    va_list va;
+    va_copy(va, ap);
+    size_t r = vsnprintf(&*msg.begin(), msg.size(), fmt, va);
+    va_end(ap);
+
+    if (msg.size() < r) {
+      msg.resize(r);
+      va_copy(va, ap);
+      r = vsnprintf(&*msg.begin(), msg.size(), fmt, va);
+      va_end(ap);
+    }
+    msg.resize(r);
+
+    if (dws->log_error != nullptr) dws->log_error(msg);
 }
 
 void access_log(webserver* dws, string uri) {


### PR DESCRIPTION
### Identify the Bug

https://github.com/etr/libhttpserver/issues/297

### Description of the Change

This makes it generate full log messages.

There are a small number of places where error_log is called where it is expected to apply `printf` style formatting to it's extra arguments. In most of them, the extra arguments are the most important.

### Alternate Designs

None.

### Possible Drawbacks

None?

### Verification Process

Building with this commit allowed me to fix the issue I was having using the library. 

### Release Notes

Make `httpserver::create_webserver::log_error` callback get fully formatted messages.