### PR TITLE
fix #292 handle argument keys with multiple values

### DIFF
--- a/examples/hello_world.cpp
+++ b/examples/hello_world.cpp
@@ -33,7 +33,7 @@ class hello_world_resource : public httpserver::http_resource {
 std::shared_ptr<httpserver::http_response> hello_world_resource::render(const httpserver::http_request& req) {
     // It is possible to store data inside the resource object that can be altered through the requests
     std::cout << "Data was: " << data << std::endl;
-    std::string_view datapar = req.get_arg("data");
+    std::string_view datapar = req.get_arg_flat("data");
     set_some_data(datapar == "" ? "no data passed!!!" : std::string(datapar));
     std::cout << "Now data is:" << data << std::endl;
 

--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -32,7 +32,7 @@ const char http_request::EMPTY[] = "";
 
 struct arguments_accumulator {
     unescaper_ptr unescaper;
-    http::arg_map* arguments;
+    std::map<std::string, std::vector<std::string>, http::arg_comparator>* arguments;
 };
 
 void http_request::set_method(const std::string& method) {
@@ -104,33 +104,61 @@ const http::header_view_map http_request::get_cookies() const {
     return get_headerlike_values(MHD_COOKIE_KIND);
 }
 
-std::string_view http_request::get_arg(std::string_view key) const {
-    std::map<std::string, std::string>::const_iterator it = cache->unescaped_args.find(std::string(key));
+void http_request::populate_args() const {
+    if (!cache->unescaped_args.empty()) {
+        return;
+    }
+    arguments_accumulator aa;
+    aa.unescaper = unescaper;
+    aa.arguments = &cache->unescaped_args;
+    MHD_get_connection_values(underlying_connection, MHD_GET_ARGUMENT_KIND, &build_request_args, reinterpret_cast<void*>(&aa));
+}
+
+http::http_arg_value http_request::get_arg(std::string_view key) const {
+    populate_args();
+
+    auto it = cache->unescaped_args.find(std::string(key));
+    if (it != cache->unescaped_args.end()) {
+        http::http_arg_value arg;
+        arg.values.reserve(it->second.size());
+        for (const auto& value : it->second) {
+            arg.values.push_back(value);
+        }
+        return arg;
+    }
+    return http::http_arg_value();
+}
+
+std::string_view http_request::get_arg_flat(std::string_view key) const {
+    auto const it = cache->unescaped_args.find(std::string(key));
 
     if (it != cache->unescaped_args.end()) {
-        return it->second;
+        return it->second[0];
     }
 
     return get_connection_value(key, MHD_GET_ARGUMENT_KIND);
 }
 
 const http::arg_view_map http_request::get_args() const {
+    populate_args();
+
     http::arg_view_map arguments;
-
-    if (!cache->unescaped_args.empty()) {
-        arguments.insert(cache->unescaped_args.begin(), cache->unescaped_args.end());
-        return arguments;
+    for (const auto& [key, value] : cache->unescaped_args) {
+        auto& arg_values = arguments[key];
+        for (const auto& v : value) {
+            arg_values.values.push_back(v);
+        }
     }
-
-    arguments_accumulator aa;
-    aa.unescaper = unescaper;
-    aa.arguments = &cache->unescaped_args;
-
-    MHD_get_connection_values(underlying_connection, MHD_GET_ARGUMENT_KIND, &build_request_args, reinterpret_cast<void*>(&aa));
-
-    arguments.insert(cache->unescaped_args.begin(), cache->unescaped_args.end());
-
     return arguments;
+}
+
+const std::map<std::string_view, std::string_view, http::arg_comparator> http_request::get_args_flat() const {
+    populate_args();
+    std::map<std::string_view, std::string_view, http::arg_comparator> ret;
+    for (const auto&[key, val] : cache->unescaped_args) {
+        ret[key] = val[0];
+    }
+    return ret;
 }
 
 http::file_info& http_request::get_or_create_file_info(const std::string& key, const std::string& upload_file_name) {
@@ -155,7 +183,7 @@ MHD_Result http_request::build_request_args(void *cls, enum MHD_ValueKind kind, 
     std::string value = ((arg_value == nullptr) ? "" : arg_value);
 
     http::base_unescaper(&value, aa->unescaper);
-    (*aa->arguments)[key] = value;
+    (*aa->arguments)[key].push_back(value);
     return MHD_YES;
 }
 

--- a/src/http_utils.cpp
+++ b/src/http_utils.cpp
@@ -510,8 +510,7 @@ const std::string load_file(const std::string& filename) {
     }
 }
 
-template<typename map_t>
-void dump_map(std::ostream& os, const std::string& prefix, const map_t& map) {
+void dump_header_map(std::ostream& os, const std::string& prefix, const http::header_view_map &map) {
     auto it = map.begin();
     auto end = map.end();
 
@@ -524,12 +523,23 @@ void dump_map(std::ostream& os, const std::string& prefix, const map_t& map) {
     }
 }
 
-void dump_header_map(std::ostream& os, const std::string& prefix, const http::header_view_map &map) {
-    dump_map<http::header_view_map>(os, prefix, map);
-}
-
 void dump_arg_map(std::ostream& os, const std::string& prefix, const http::arg_view_map &map) {
-    dump_map<http::arg_view_map>(os, prefix, map);
+    auto it = map.begin();
+    auto end = map.end();
+
+    if (map.size()) {
+        os << "    " << prefix << " [";
+        for (; it != end; ++it) {
+            os << (*it).first << ":[";
+            std::string sep = "";
+            for (const auto& v : it->second.values) {
+                os << sep << "\"" << v << "\"";
+                sep = ", ";
+            }
+            os << "] ";
+        }
+        os << "]" << std::endl;
+    }
 }
 
 size_t base_unescaper(std::string* s, unescaper_ptr unescaper) {

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -134,10 +134,16 @@ class http_request {
 
      /**
       * Method used to get all args passed with the request.
-      * @param result a map<string, string> > that will be filled with all args
       * @result the size of the map
      **/
      const http::arg_view_map get_args() const;
+
+     /**
+      * Method used to get all args passed with the request. If any key has multiple
+      * values, one value is chosen and returned.
+      * @result the size of the map
+     **/
+     const std::map<std::string_view, std::string_view, http::arg_comparator> get_args_flat() const;
 
      /**
       * Method to get or create a file info struct in the map if the provided filename is already in the map
@@ -174,9 +180,17 @@ class http_request {
      /**
       * Method used to get a specific argument passed with the request.
       * @param ket the specific argument to get the value from
+      * @return the value(s) of the arg.
+     **/
+     http::http_arg_value get_arg(std::string_view key) const;
+
+     /**
+      * Method used to get a specific argument passed with the request.
+      * If the arg key has more than one value, only one is returned.
+      * @param ket the specific argument to get the value from
       * @return the value of the arg.
      **/
-     std::string_view get_arg(std::string_view key) const;
+     std::string_view get_arg_flat(std::string_view key) const;
 
      /**
       * Method used to get the content of the request.
@@ -298,7 +312,7 @@ class http_request {
       * @param value The value assumed by the argument
      **/
      void set_arg(const std::string& key, const std::string& value) {
-         cache->unescaped_args[key] = value.substr(0, content_size_limit);
+         cache->unescaped_args[key].push_back(value.substr(0, content_size_limit));
      }
 
      /**
@@ -308,9 +322,17 @@ class http_request {
       * @param size The size in number of char of the value parameter.
      **/
      void set_arg(const char* key, const char* value, size_t size) {
-         cache->unescaped_args[key] = std::string(value, std::min(size, content_size_limit));
+         cache->unescaped_args[key].push_back(std::string(value, std::min(size, content_size_limit)));
      }
 
+     /**
+      * Method used to set an argument value by key. If a key already exists, overwrites it.
+      * @param key The name identifying the argument
+      * @param value The value assumed by the argument
+     **/
+     void set_arg_flat(const std::string& key, const std::string& value) {
+         cache->unescaped_args[key] = { (value.substr(0, content_size_limit)) };
+     }
      /**
       * Method used to set the content of the request
       * @param content The content to set.
@@ -366,9 +388,8 @@ class http_request {
       * @param args The args key-value map to set for the request.
      **/
      void set_args(const std::map<std::string, std::string>& args) {
-         std::map<std::string, std::string>::const_iterator it;
-         for (it = args.begin(); it != args.end(); ++it) {
-             this->cache->unescaped_args[it->first] = it->second.substr(0, content_size_limit);
+         for (auto const& [key, value] : args) {
+             this->cache->unescaped_args[key].push_back(value.substr(0, content_size_limit));
          }
      }
 
@@ -386,9 +407,11 @@ class http_request {
         std::string querystring;
         std::string requestor_ip;
         std::string digested_user;
-        http::arg_map unescaped_args;
+        std::map<std::string, std::vector<std::string>, http::arg_comparator> unescaped_args;
      };
      std::unique_ptr<http_request_data_cache> cache;
+     // Populate the data cache unescaped_args
+     void populate_args() const;
 
      friend class webserver;
      friend struct details::modded_request;

--- a/src/httpserver/http_utils.hpp
+++ b/src/httpserver/http_utils.hpp
@@ -316,10 +316,41 @@ class arg_comparator {
      }
 };
 
+class http_arg_value {
+ public:
+
+    std::string_view get_flat_value() const
+    {
+        return values.empty() ? "" : values[0];
+    }
+
+    std::vector<std::string_view> get_all_values() const
+    {
+        return values;
+    }
+
+    operator std::string() const
+    {
+        return std::string(get_flat_value());
+    }
+
+    operator std::vector<std::string>() const
+    {
+        std::vector<std::string> result;
+        for (auto const & value : values) {
+            result.push_back(std::string(value));
+        }
+        return result;
+    }
+
+    std::vector<std::string_view> values;
+};
+
 using header_map = std::map<std::string, std::string, http::header_comparator>;
 using header_view_map = std::map<std::string_view, std::string_view, http::header_comparator>;
-using arg_map = std::map<std::string, std::string, http::arg_comparator>;
-using arg_view_map = std::map<std::string_view, std::string_view, http::arg_comparator>;
+using arg_map = std::map<std::string, http_arg_value, http::arg_comparator>;
+using arg_view_map = std::map<std::string_view, http_arg_value, http::arg_comparator>;
+
 
 struct ip_representation {
     http_utils::IP_version_T ip_version;

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -463,7 +463,7 @@ MHD_Result webserver::post_iterator(void *cls, enum MHD_ValueKind kind,
 
     try {
         if (filename == nullptr || mr->ws->file_upload_target != FILE_UPLOAD_DISK_ONLY) {
-            mr->dhr->set_arg(key, std::string(mr->dhr->get_arg(key)) + std::string(data, size));
+            mr->dhr->set_arg_flat(key, std::string(mr->dhr->get_arg(key)) + std::string(data, size));
         }
 
         if (filename && *filename != '\0' && mr->ws->file_upload_target != FILE_UPLOAD_MEMORY_ONLY) {

--- a/test/unit/http_utils_test.cpp
+++ b/test/unit/http_utils_test.cpp
@@ -618,25 +618,25 @@ LT_BEGIN_AUTO_TEST(http_utils_suite, dump_header_map_no_prefix)
 LT_END_AUTO_TEST(dump_header_map_no_prefix)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, dump_arg_map)
-    std::map<std::string_view, std::string_view, httpserver::http::arg_comparator> arg_map;
-    arg_map["ARG_ONE"] = "VALUE_ONE";
-    arg_map["ARG_TWO"] = "VALUE_TWO";
-    arg_map["ARG_THREE"] = "VALUE_THREE";
+    httpserver::http::arg_view_map arg_map;
+    arg_map["ARG_ONE"].values.push_back("VALUE_ONE");
+    arg_map["ARG_TWO"].values.push_back("VALUE_TWO");
+    arg_map["ARG_THREE"].values.push_back("VALUE_THREE");
 
     std::stringstream ss;
     httpserver::http::dump_arg_map(ss, "prefix", arg_map);
-    LT_CHECK_EQ(ss.str(), "    prefix [ARG_ONE:\"VALUE_ONE\" ARG_TWO:\"VALUE_TWO\" ARG_THREE:\"VALUE_THREE\" ]\n");
+    LT_CHECK_EQ(ss.str(), "    prefix [ARG_ONE:[\"VALUE_ONE\"] ARG_TWO:[\"VALUE_TWO\"] ARG_THREE:[\"VALUE_THREE\"] ]\n");
 LT_END_AUTO_TEST(dump_arg_map)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, dump_arg_map_no_prefix)
-    std::map<std::string_view, std::string_view, httpserver::http::arg_comparator> arg_map;
-    arg_map["ARG_ONE"] = "VALUE_ONE";
-    arg_map["ARG_TWO"] = "VALUE_TWO";
-    arg_map["ARG_THREE"] = "VALUE_THREE";
+    httpserver::http::arg_view_map arg_map;
+    arg_map["ARG_ONE"].values.push_back("VALUE_ONE");
+    arg_map["ARG_TWO"].values.push_back("VALUE_TWO");
+    arg_map["ARG_THREE"].values.push_back("VALUE_THREE");
 
     std::stringstream ss;
     httpserver::http::dump_arg_map(ss, "", arg_map);
-    LT_CHECK_EQ(ss.str(), "     [ARG_ONE:\"VALUE_ONE\" ARG_TWO:\"VALUE_TWO\" ARG_THREE:\"VALUE_THREE\" ]\n");
+    LT_CHECK_EQ(ss.str(), "     [ARG_ONE:[\"VALUE_ONE\"] ARG_TWO:[\"VALUE_TWO\"] ARG_THREE:[\"VALUE_THREE\"] ]\n");
 LT_END_AUTO_TEST(dump_arg_map_no_prefix)
 
 LT_BEGIN_AUTO_TEST_ENV()


### PR DESCRIPTION
### Identify the Bug

#292 

### Description of the Change

This change allows the server to handle argument keys with multiple values e.g. url?arg=param&arg=what

Previous, the arg key would just be overwritten with the next value. This change adds a http_arg_value type to house all the values for a given key.

Adjust existing get_arg(s) methods, and add some get_arg_flat type methods that still just return the first value for a given key.

Add a test case for multiple valued keys.

Add a test case for a large file upload that triggers chunking behavior of MHD. This causes the server to concatenate file chunks within the first value of the given arg key, so the test ensures that this behavior is not affected by the changes.

### Alternate Designs

Design is according to discussion in #292 

### Possible Drawbacks

Small changes to public API.

### Verification Process

Additional testing added as in change description. In particular, verify that large file handling behavior has not regressed.

### Release Notes

- Multiple valued arguments are now supported, e.g. URLs containing ?arg=param1&arg=param2. `get_arg()` now returns an `http_arg_value` type containing a collection of all values associated with the requested key. `get_arg_flat()` retains the old behavior where just one value is selected and returned.
