### PR TITLE
Consider family_url in ordering of http_endpoint.

### DIFF
--- a/src/details/http_endpoint.cpp
+++ b/src/details/http_endpoint.cpp
@@ -142,6 +142,7 @@ http_endpoint& http_endpoint::operator =(const http_endpoint& h) {
 }
 
 bool http_endpoint::operator <(const http_endpoint& b) const {
+    if (family_url != b.family_url) return family_url;
     COMPARATOR(url_normalized, b.url_normalized, std::toupper);
 }
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -198,7 +198,7 @@ bool webserver::register_resource(const std::string& resource, http_resource* hr
 
     pair<map<details::http_endpoint, http_resource*>::iterator, bool> result = registered_resources.insert(map<details::http_endpoint, http_resource*>::value_type(idx, hrm));
 
-    if (result.second) {
+    if (!family && result.second) {
         registered_resources_str.insert(pair<string, http_resource*>(idx.get_url_complete(), result.first->second));
     }
 

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -394,7 +394,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, duplicate_endpoints)
     LT_CHECK_EQ(false, ws->register_resource("OK/", &ok2));
 
     // Check how family interacts.
-    LT_CHECK_EQ(false, ws->register_resource("OK", &ok2, true));
+    LT_CHECK_EQ(true, ws->register_resource("OK", &ok2, true));
 
     // Check that switched case does the right thing, whatever that is here.
 #ifdef CASE_INSENSITIVE
@@ -409,7 +409,7 @@ LT_END_AUTO_TEST(duplicate_endpoints)
 LT_BEGIN_AUTO_TEST(basic_suite, family_endpoints)
     static_resource ok1("1"), ok2("2");
     LT_CHECK_EQ(true, ws->register_resource("OK", &ok1));
-    LT_CHECK_EQ(false, ws->register_resource("OK", &ok2, true));
+    LT_CHECK_EQ(true, ws->register_resource("OK", &ok2, true));
 
     curl_global_init(CURL_GLOBAL_ALL);
 
@@ -451,7 +451,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, family_endpoints)
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
     res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
-    LT_CHECK_EQ(s, "Not Found");  // Not registured.
+    LT_CHECK_EQ(s, "2");
     curl_easy_cleanup(curl);
     }
 
@@ -494,7 +494,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, family_endpoints)
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
     res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
-    LT_CHECK_EQ(s, "Not Found");  // Not registured.
+    LT_CHECK_EQ(s, "2");
     curl_easy_cleanup(curl);
     }
 #endif

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -423,7 +423,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, family_endpoints)
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
     res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
-    LT_CHECK_EQ(s, "1");   // Not sure why regex wins, but it does...
+    LT_CHECK_EQ(s, "1");
     curl_easy_cleanup(curl);
     }
 
@@ -437,7 +437,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, family_endpoints)
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
     res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
-    LT_CHECK_EQ(s, "1");   // Not sure why regex wins, but it does...
+    LT_CHECK_EQ(s, "1");
     curl_easy_cleanup(curl);
     }
 
@@ -466,7 +466,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, family_endpoints)
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
     res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
-    LT_CHECK_EQ(s, "1");   // Not sure why regex wins, but it does...
+    LT_CHECK_EQ(s, "1");
     curl_easy_cleanup(curl);
     }
 
@@ -480,7 +480,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, family_endpoints)
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
     res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
-    LT_CHECK_EQ(s, "1");   // Not sure why regex wins, but it does...
+    LT_CHECK_EQ(s, "1");
     curl_easy_cleanup(curl);
     }
 

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -406,6 +406,100 @@ LT_BEGIN_AUTO_TEST(basic_suite, duplicate_endpoints)
 #endif
 LT_END_AUTO_TEST(duplicate_endpoints)
 
+LT_BEGIN_AUTO_TEST(basic_suite, family_endpoints)
+    static_resource ok1("1"), ok2("2");
+    LT_CHECK_EQ(true, ws->register_resource("OK", &ok1));
+    LT_CHECK_EQ(false, ws->register_resource("OK", &ok2, true));
+
+    curl_global_init(CURL_GLOBAL_ALL);
+
+    {
+    string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/OK");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(s, "1");   // Not sure why regex wins, but it does...
+    curl_easy_cleanup(curl);
+    }
+
+    {
+    string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/OK/");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(s, "1");   // Not sure why regex wins, but it does...
+    curl_easy_cleanup(curl);
+    }
+
+    {
+    string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/OK/go");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(s, "Not Found");  // Not registured.
+    curl_easy_cleanup(curl);
+    }
+
+#ifdef CASE_INSENSITIVE
+    {
+    string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/OK");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(s, "1");   // Not sure why regex wins, but it does...
+    curl_easy_cleanup(curl);
+    }
+
+    {
+    string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/OK/");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(s, "1");   // Not sure why regex wins, but it does...
+    curl_easy_cleanup(curl);
+    }
+
+    {
+    string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/OK/go");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(s, "Not Found");  // Not registured.
+    curl_easy_cleanup(curl);
+    }
+#endif
+LT_END_AUTO_TEST(family_endpoints)
+
 LT_BEGIN_AUTO_TEST(basic_suite, overlapping_endpoints)
     // Setup two different resources that can both match the same URL.
     static_resource ok1("1"), ok2("2");

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -418,7 +418,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, overlapping_endpoints)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/foo/bar/");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/foo/bar/");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -436,7 +436,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, overlapping_endpoints)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/foo/bar/");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/foo/bar/");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1267,7 +1267,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, non_family_url_with_regex_like_pieces)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/settings/{}");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/settings/{}");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1290,7 +1290,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, regex_url_exact_match)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/foo/a/bar/");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/foo/a/bar/");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1309,7 +1309,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, regex_url_exact_match)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/foo/{v|[a-z]}/bar/");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/foo/{v|[a-z]}/bar/");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);


### PR DESCRIPTION
This will allow calling register_resource independently for a path as a family and non-family.

### Requirements for Contributing a Bug Fix

### Identify the Bug

https://github.com/etr/libhttpserver/issues/305

### Description of the Change

Consider family_url in ordering of http_endpoint.

### Alternate Designs

None.

### Possible Drawbacks

This will change behavior of programs in some cases. In general however, those cases are already not doing what the user likely expects.

### Verification Process

TBD

### Release Notes

Allow register_resource to use the same path for family and non-family cases in the same webserver.
