### PR TITLE
Modify some integration tests to allow them to pass on more limited systems

### DIFF
--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -316,7 +316,7 @@ class print_response_resource : public http_resource {
 
 #define STR2(p) #p
 #define STR(p) STR2(p)
-#define PORTS STR(PORT)
+#define PORT_STRING STR(PORT)
 
 LT_BEGIN_SUITE(basic_suite)
     webserver* ws;
@@ -347,7 +347,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, two_endpoints)
     {
         CURL *curl = curl_easy_init();
         CURLcode res;
-        curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/OK");
+        curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/OK");
         curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -361,7 +361,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, two_endpoints)
     {
         CURL *curl = curl_easy_init();
         CURLcode res;
-        curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/NOK");
+        curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/NOK");
         curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &t);
@@ -379,7 +379,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, read_body)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -396,7 +396,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, read_long_body)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -414,7 +414,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, resource_setting_header)
     map<string, string> ss;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -434,7 +434,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, resource_setting_cookie)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");
     curl_easy_setopt(curl, CURLOPT_COOKIEJAR, "");
@@ -466,7 +466,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, request_with_header)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
 
     struct curl_slist *list = nullptr;
@@ -489,7 +489,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, request_with_cookie)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -507,7 +507,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
 
     {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -516,7 +516,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
 
     {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -525,7 +525,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
 
     {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -534,7 +534,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
 
     {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PATCH");
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -543,7 +543,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
 /*
     {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "CONNECT");
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -553,7 +553,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
 
     {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, nullptr);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 0);
@@ -573,7 +573,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
 
     s = "";
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -584,7 +584,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
 
     s = "";
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -595,7 +595,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
 
     s = "";
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -607,7 +607,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
 /*
     s = "";
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "CONNECT");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -619,7 +619,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
 
     s = "";
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "NOT_EXISTENT");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -630,7 +630,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
 
     s = "";
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, nullptr);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 0);
@@ -649,7 +649,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, postprocessor)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "arg1=lib&arg2=httpserver");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -669,7 +669,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, same_key_different_value)
     // The curl default content type triggers the file processing
     // logic in the webserver. However, since there is no actual
     // file, the arg handling should be the same.
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "arg=inertia&arg=isaproperty&arg=ofmatter");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -687,7 +687,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, same_key_different_value_plain_content)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base?arg=beep&arg=boop&arg=hello&arg=what");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base?arg=beep&arg=boop&arg=hello&arg=what");
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "arg=beep&arg=boop&arg=hello&arg=what");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -707,7 +707,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, empty_arg)
     curl_global_init(CURL_GLOBAL_ALL);
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "arg1");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     res = curl_easy_perform(curl);
@@ -721,7 +721,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, no_response)
     curl_global_init(CURL_GLOBAL_ALL);
 
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -737,7 +737,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, empty_response)
     curl_global_init(CURL_GLOBAL_ALL);
 
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -755,7 +755,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, regex_matching)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/regex/matching/number/10");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/regex/matching/number/10");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -773,7 +773,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, regex_matching_arg)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/this/captures/whatever/passed/in/input");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/this/captures/whatever/passed/in/input");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -792,7 +792,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, regex_matching_arg_custom)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/this/captures/numeric/11/passed/in/input");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/this/captures/numeric/11/passed/in/input");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -806,7 +806,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, regex_matching_arg_custom)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/this/captures/numeric/text/passed/in/input");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/this/captures/numeric/text/passed/in/input");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -828,7 +828,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, querystring_processing)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/this/captures/args/passed/in/the/querystring?arg=first&arg2=second");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/this/captures/args/passed/in/the/querystring?arg=first&arg2=second");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -846,7 +846,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, full_arguments_processing)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/this/captures/args/passed/in/the/querystring?arg=argument");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/this/captures/args/passed/in/the/querystring?arg=argument");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -864,7 +864,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, querystring_query_processing)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/this/captures/args/passed/in/the/querystring?arg1=value1&arg2=value2&arg3=value3");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/this/captures/args/passed/in/the/querystring?arg1=value1&arg2=value2&arg3=value3");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -883,7 +883,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, register_unregister)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -898,7 +898,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, register_unregister)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -919,7 +919,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, register_unregister)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -939,7 +939,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -957,7 +957,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_empty)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -975,7 +975,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_default_content_type)
     map<string, string> ss;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, headerfunc);
     curl_easy_setopt(curl, CURLOPT_HEADERDATA, &ss);
@@ -994,7 +994,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_missing)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1018,7 +1018,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_dir)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1042,7 +1042,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, exception_forces_500)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1065,7 +1065,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, untyped_error_forces_500)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1089,7 +1089,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, request_is_printable)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1124,7 +1124,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, response_is_printable)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1156,7 +1156,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, long_path_pieces)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/settings/somestringthatisreallylong/with_really_a_lot_of_content/and_underscores_and_looooooooooooooooooong_stuff");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/settings/somestringthatisreallylong/with_really_a_lot_of_content/and_underscores_and_looooooooooooooooooong_stuff");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1174,7 +1174,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, url_with_regex_like_pieces)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/settings/{}");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/settings/{}");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1195,7 +1195,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, method_not_allowed_header)
     map<string, string> ss;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -218,6 +218,7 @@ class empty_response_resource : public http_resource {
      }
 };
 
+#ifndef HTTPSERVER_NO_LOCAL_FS
 class file_response_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
@@ -238,6 +239,7 @@ class file_response_resource_default_content_type : public http_resource {
          return shared_ptr<file_response>(new file_response("test_content", 200));
      }
 };
+#endif // HTTPSERVER_NO_LOCAL_FS
 
 class file_response_resource_missing : public http_resource {
  public:
@@ -246,12 +248,14 @@ class file_response_resource_missing : public http_resource {
      }
 };
 
+#ifndef HTTPSERVER_NO_LOCAL_FS
 class file_response_resource_dir : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
          return shared_ptr<file_response>(new file_response("integ", 200));
      }
 };
+#endif // HTTPSERVER_NO_LOCAL_FS
 
 class exception_resource : public http_resource {
  public:
@@ -304,11 +308,21 @@ class print_response_resource : public http_resource {
      stringstream* ss;
 };
 
+#ifdef HTTPSERVER_PORT
+#define PORT HTTPSERVER_PORT
+#else
+#define PORT 8080
+#endif  // PORT
+
+#define STR2(p) #p
+#define STR(p) STR2(p)
+#define PORTS STR(PORT)
+
 LT_BEGIN_SUITE(basic_suite)
     webserver* ws;
 
     void set_up() {
-        ws = new webserver(create_webserver(8080));
+        ws = new webserver(create_webserver(PORT));
         ws->start(false);
     }
 
@@ -333,7 +347,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, two_endpoints)
     {
         CURL *curl = curl_easy_init();
         CURLcode res;
-        curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/OK");
+        curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/OK");
         curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -347,7 +361,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, two_endpoints)
     {
         CURL *curl = curl_easy_init();
         CURLcode res;
-        curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/NOK");
+        curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/NOK");
         curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &t);
@@ -365,7 +379,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, read_body)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -382,7 +396,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, read_long_body)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -400,7 +414,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, resource_setting_header)
     map<string, string> ss;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -420,7 +434,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, resource_setting_cookie)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");
     curl_easy_setopt(curl, CURLOPT_COOKIEJAR, "");
@@ -452,7 +466,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, request_with_header)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
 
     struct curl_slist *list = nullptr;
@@ -475,7 +489,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, request_with_cookie)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -493,7 +507,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
 
     {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -502,7 +516,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
 
     {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -511,7 +525,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
 
     {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -520,7 +534,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
 
     {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PATCH");
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -529,7 +543,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
 /*
     {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "CONNECT");
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -539,7 +553,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, complete)
 
     {
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, nullptr);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 0);
@@ -559,7 +573,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
 
     s = "";
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -570,7 +584,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
 
     s = "";
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -581,7 +595,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
 
     s = "";
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -593,7 +607,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
 /*
     s = "";
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "CONNECT");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -605,7 +619,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
 
     s = "";
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "NOT_EXISTENT");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -616,7 +630,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, only_render)
 
     s = "";
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, nullptr);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 0);
@@ -635,7 +649,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, postprocessor)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "arg1=lib&arg2=httpserver");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -655,7 +669,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, same_key_different_value)
     // The curl default content type triggers the file processing
     // logic in the webserver. However, since there is no actual
     // file, the arg handling should be the same.
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "arg=inertia&arg=isaproperty&arg=ofmatter");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -673,7 +687,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, same_key_different_value_plain_content)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base?arg=beep&arg=boop&arg=hello&arg=what");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base?arg=beep&arg=boop&arg=hello&arg=what");
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "arg=beep&arg=boop&arg=hello&arg=what");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -693,7 +707,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, empty_arg)
     curl_global_init(CURL_GLOBAL_ALL);
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "arg1");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     res = curl_easy_perform(curl);
@@ -707,7 +721,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, no_response)
     curl_global_init(CURL_GLOBAL_ALL);
 
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -723,7 +737,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, empty_response)
     curl_global_init(CURL_GLOBAL_ALL);
 
     CURL* curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     CURLcode res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);
@@ -741,7 +755,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, regex_matching)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/regex/matching/number/10");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/regex/matching/number/10");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -759,7 +773,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, regex_matching_arg)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/this/captures/whatever/passed/in/input");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/this/captures/whatever/passed/in/input");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -778,7 +792,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, regex_matching_arg_custom)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/this/captures/numeric/11/passed/in/input");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/this/captures/numeric/11/passed/in/input");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -792,7 +806,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, regex_matching_arg_custom)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/this/captures/numeric/text/passed/in/input");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/this/captures/numeric/text/passed/in/input");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -814,7 +828,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, querystring_processing)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/this/captures/args/passed/in/the/querystring?arg=first&arg2=second");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/this/captures/args/passed/in/the/querystring?arg=first&arg2=second");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -832,7 +846,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, full_arguments_processing)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/this/captures/args/passed/in/the/querystring?arg=argument");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/this/captures/args/passed/in/the/querystring?arg=argument");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -850,7 +864,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, querystring_query_processing)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/this/captures/args/passed/in/the/querystring?arg1=value1&arg2=value2&arg3=value3");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/this/captures/args/passed/in/the/querystring?arg1=value1&arg2=value2&arg3=value3");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -869,7 +883,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, register_unregister)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -884,7 +898,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, register_unregister)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -905,7 +919,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, register_unregister)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -916,6 +930,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, register_unregister)
     }
 LT_END_AUTO_TEST(register_unregister)
 
+#ifndef HTTPSERVER_NO_LOCAL_FS
 LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource)
     file_response_resource resource;
     ws->register_resource("base", &resource);
@@ -924,7 +939,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -942,7 +957,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_empty)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -960,7 +975,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_default_content_type)
     map<string, string> ss;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, headerfunc);
     curl_easy_setopt(curl, CURLOPT_HEADERDATA, &ss);
@@ -969,6 +984,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_default_content_type)
     LT_CHECK_EQ(ss["Content-Type"], "application/octet-stream");
     curl_easy_cleanup(curl);
 LT_END_AUTO_TEST(file_serving_resource_default_content_type)
+#endif // HTTPSERVER_NO_LOCAL_FS
 
 LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_missing)
     file_response_resource_missing resource;
@@ -978,7 +994,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_missing)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -993,6 +1009,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_missing)
     curl_easy_cleanup(curl);
 LT_END_AUTO_TEST(file_serving_resource_missing)
 
+#ifndef HTTPSERVER_NO_LOCAL_FS
 LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_dir)
     file_response_resource_dir resource;
     ws->register_resource("base", &resource);
@@ -1001,7 +1018,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_dir)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1015,6 +1032,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_dir)
 
     curl_easy_cleanup(curl);
 LT_END_AUTO_TEST(file_serving_resource_dir)
+#endif // HTTPSERVER_NO_LOCAL_FS
 
 LT_BEGIN_AUTO_TEST(basic_suite, exception_forces_500)
     exception_resource resource;
@@ -1024,7 +1042,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, exception_forces_500)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1047,7 +1065,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, untyped_error_forces_500)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1071,7 +1089,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, request_is_printable)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1106,7 +1124,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, response_is_printable)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1138,7 +1156,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, long_path_pieces)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/settings/somestringthatisreallylong/with_really_a_lot_of_content/and_underscores_and_looooooooooooooooooong_stuff");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/settings/somestringthatisreallylong/with_really_a_lot_of_content/and_underscores_and_looooooooooooooooooong_stuff");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1156,7 +1174,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, url_with_regex_like_pieces)
     string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/settings/{}");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/settings/{}");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -1177,7 +1195,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, method_not_allowed_header)
     map<string, string> ss;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -239,7 +239,7 @@ class file_response_resource_default_content_type : public http_resource {
          return shared_ptr<file_response>(new file_response("test_content", 200));
      }
 };
-#endif // HTTPSERVER_NO_LOCAL_FS
+#endif  // HTTPSERVER_NO_LOCAL_FS
 
 class file_response_resource_missing : public http_resource {
  public:
@@ -255,7 +255,7 @@ class file_response_resource_dir : public http_resource {
          return shared_ptr<file_response>(new file_response("integ", 200));
      }
 };
-#endif // HTTPSERVER_NO_LOCAL_FS
+#endif  // HTTPSERVER_NO_LOCAL_FS
 
 class exception_resource : public http_resource {
  public:
@@ -984,7 +984,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_default_content_type)
     LT_CHECK_EQ(ss["Content-Type"], "application/octet-stream");
     curl_easy_cleanup(curl);
 LT_END_AUTO_TEST(file_serving_resource_default_content_type)
-#endif // HTTPSERVER_NO_LOCAL_FS
+#endif  // HTTPSERVER_NO_LOCAL_FS
 
 LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_missing)
     file_response_resource_missing resource;
@@ -1032,7 +1032,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_dir)
 
     curl_easy_cleanup(curl);
 LT_END_AUTO_TEST(file_serving_resource_dir)
-#endif // HTTPSERVER_NO_LOCAL_FS
+#endif  // HTTPSERVER_NO_LOCAL_FS
 
 LT_BEGIN_AUTO_TEST(basic_suite, exception_forces_500)
     exception_resource resource;

--- a/test/integ/deferred.cpp
+++ b/test/integ/deferred.cpp
@@ -111,7 +111,7 @@ class deferred_resource_with_data : public http_resource {
 
 #define STR2(p) #p
 #define STR(p) STR2(p)
-#define PORTS STR(PORT)
+#define PORT_STRING STR(PORT)
 
 LT_BEGIN_SUITE(deferred_suite)
     webserver* ws;
@@ -137,7 +137,7 @@ LT_BEGIN_AUTO_TEST(deferred_suite, deferred_response_suite)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -155,7 +155,7 @@ LT_BEGIN_AUTO_TEST(deferred_suite, deferred_response_with_data)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);

--- a/test/integ/deferred.cpp
+++ b/test/integ/deferred.cpp
@@ -103,11 +103,21 @@ class deferred_resource_with_data : public http_resource {
      }
 };
 
+#ifdef HTTPSERVER_PORT
+#define PORT HTTPSERVER_PORT
+#else
+#define PORT 8080
+#endif  // PORT
+
+#define STR2(p) #p
+#define STR(p) STR2(p)
+#define PORTS STR(PORT)
+
 LT_BEGIN_SUITE(deferred_suite)
     webserver* ws;
 
     void set_up() {
-        ws = new webserver(create_webserver(8080));
+        ws = new webserver(create_webserver(PORT));
         ws->start(false);
     }
 
@@ -127,7 +137,7 @@ LT_BEGIN_AUTO_TEST(deferred_suite, deferred_response_suite)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -145,7 +155,7 @@ LT_BEGIN_AUTO_TEST(deferred_suite, deferred_response_with_data)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -39,6 +39,16 @@
 
 using std::shared_ptr;
 
+#ifdef HTTPSERVER_PORT
+#define PORT HTTPSERVER_PORT
+#else
+#define PORT 8080
+#endif  // PORT
+
+#define STR2(p) #p
+#define STR(p) STR2(p)
+#define PORTS STR(PORT)
+
 size_t writefunc(void *ptr, size_t size, size_t nmemb, std::string *s) {
     s->append(reinterpret_cast<char*>(ptr), size*nmemb);
     return size*nmemb;
@@ -71,7 +81,7 @@ LT_END_SUITE(ws_start_stop_suite)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, start_stop)
     { // NOLINT (internal scope opening - not method start)
-    httpserver::webserver ws = httpserver::create_webserver(8080);
+    httpserver::webserver ws = httpserver::create_webserver(PORT);
     ok_resource ok;
     ws.register_resource("base", &ok);
     ws.start(false);
@@ -80,7 +90,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, start_stop)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -93,7 +103,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, start_stop)
     }
 
     {
-    httpserver::webserver ws = httpserver::create_webserver(8080).start_method(httpserver::http::http_utils::INTERNAL_SELECT);
+    httpserver::webserver ws = httpserver::create_webserver(PORT).start_method(httpserver::http::http_utils::INTERNAL_SELECT);
     ok_resource ok;
     ws.register_resource("base", &ok);
     ws.start(false);
@@ -102,7 +112,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, start_stop)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -115,7 +125,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, start_stop)
     }
 
     {
-    httpserver::webserver ws = httpserver::create_webserver(8080).start_method(httpserver::http::http_utils::THREAD_PER_CONNECTION);
+    httpserver::webserver ws = httpserver::create_webserver(PORT).start_method(httpserver::http::http_utils::THREAD_PER_CONNECTION);
     ok_resource ok;
     ws.register_resource("base", &ok);
     ws.start(false);
@@ -124,7 +134,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, start_stop)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -141,7 +151,7 @@ LT_END_AUTO_TEST(start_stop)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ipv6)
     { // NOLINT (internal scope opening - not method start)
-    httpserver::webserver ws = httpserver::create_webserver(8080).use_ipv6();
+    httpserver::webserver ws = httpserver::create_webserver(PORT).use_ipv6();
     ok_resource ok;
     ws.register_resource("base", &ok);
     ws.start(false);
@@ -150,7 +160,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ipv6)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
@@ -166,7 +176,7 @@ LT_END_AUTO_TEST(ipv6)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, dual_stack)
     { // NOLINT (internal scope opening - not method start)
-    httpserver::webserver ws = httpserver::create_webserver(8080).use_dual_stack();
+    httpserver::webserver ws = httpserver::create_webserver(PORT).use_dual_stack();
     ok_resource ok;
     ws.register_resource("base", &ok);
     ws.start(false);
@@ -175,7 +185,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, dual_stack)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
@@ -192,7 +202,7 @@ LT_END_AUTO_TEST(dual_stack)
 #endif
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, sweet_kill)
-    httpserver::webserver ws = httpserver::create_webserver(8080);
+    httpserver::webserver ws = httpserver::create_webserver(PORT);
     ok_resource ok;
     ws.register_resource("base", &ok);
     ws.start(false);
@@ -202,7 +212,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, sweet_kill)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -219,7 +229,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, sweet_kill)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -230,7 +240,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, sweet_kill)
 LT_END_AUTO_TEST(sweet_kill)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, disable_options)
-    httpserver::webserver ws = httpserver::create_webserver(8080)
+    httpserver::webserver ws = httpserver::create_webserver(PORT)
         .no_ssl()
         .no_ipv6()
         .no_debug()
@@ -249,7 +259,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, disable_options)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -262,7 +272,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, disable_options)
 LT_END_AUTO_TEST(disable_options)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, enable_options)
-    httpserver::webserver ws = httpserver::create_webserver(8080)
+    httpserver::webserver ws = httpserver::create_webserver(PORT)
         .debug()
         .pedantic()
         .deferred()
@@ -277,7 +287,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, enable_options)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -323,7 +333,7 @@ LT_END_AUTO_TEST(custom_socket)
 #endif
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, single_resource)
-    httpserver::webserver ws = httpserver::create_webserver(8080).single_resource();
+    httpserver::webserver ws = httpserver::create_webserver(PORT).single_resource();
     ok_resource ok;
     ws.register_resource("/", &ok, true);
     ws.start(false);
@@ -332,7 +342,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, single_resource)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/any/url/works");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/any/url/works");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -345,7 +355,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, single_resource)
 LT_END_AUTO_TEST(single_resource)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, single_resource_not_default_resource)
-    httpserver::webserver ws = httpserver::create_webserver(8080).single_resource();
+    httpserver::webserver ws = httpserver::create_webserver(PORT).single_resource();
     ok_resource ok;
     LT_CHECK_THROW(ws.register_resource("/other", &ok, true));
     LT_CHECK_THROW(ws.register_resource("/", &ok, false));
@@ -356,7 +366,7 @@ LT_END_AUTO_TEST(single_resource_not_default_resource)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, thread_per_connection_fails_with_max_threads)
     { // NOLINT (internal scope opening - not method start)
-    httpserver::webserver ws = httpserver::create_webserver(8080)
+    httpserver::webserver ws = httpserver::create_webserver(PORT)
         .start_method(httpserver::http::http_utils::THREAD_PER_CONNECTION)
         .max_threads(5);
     LT_CHECK_THROW(ws.start(false));
@@ -365,7 +375,7 @@ LT_END_AUTO_TEST(thread_per_connection_fails_with_max_threads)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, thread_per_connection_fails_with_max_threads_stack_size)
     { // NOLINT (internal scope opening - not method start)
-    httpserver::webserver ws = httpserver::create_webserver(8080)
+    httpserver::webserver ws = httpserver::create_webserver(PORT)
         .start_method(httpserver::http::http_utils::THREAD_PER_CONNECTION)
         .max_thread_stack_size(4*1024*1024);
     LT_CHECK_THROW(ws.start(false));
@@ -373,7 +383,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, thread_per_connection_fails_with_max_thr
 LT_END_AUTO_TEST(thread_per_connection_fails_with_max_threads_stack_size)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, tuning_options)
-    httpserver::webserver ws = httpserver::create_webserver(8080)
+    httpserver::webserver ws = httpserver::create_webserver(PORT)
         .max_connections(10)
         .max_threads(10)
         .memory_limit(10000)
@@ -389,7 +399,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, tuning_options)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -402,7 +412,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, tuning_options)
 LT_END_AUTO_TEST(tuning_options)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_base)
-    httpserver::webserver ws = httpserver::create_webserver(8080)
+    httpserver::webserver ws = httpserver::create_webserver(PORT)
         .use_ssl()
         .https_mem_key("key.pem")
         .https_mem_cert("cert.pem");
@@ -417,7 +427,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_base)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);  // avoid verifying ssl
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);  // avoid verifying ssl
-    curl_easy_setopt(curl, CURLOPT_URL, "https://localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -431,7 +441,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_base)
 LT_END_AUTO_TEST(ssl_base)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_with_protocol_priorities)
-    httpserver::webserver ws = httpserver::create_webserver(8080)
+    httpserver::webserver ws = httpserver::create_webserver(PORT)
         .use_ssl()
         .https_mem_key("key.pem")
         .https_mem_cert("cert.pem")
@@ -447,7 +457,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_with_protocol_priorities)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);  // avoid verifying ssl
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);  // avoid verifying ssl
-    curl_easy_setopt(curl, CURLOPT_URL, "https://localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -460,7 +470,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_with_protocol_priorities)
 LT_END_AUTO_TEST(ssl_with_protocol_priorities)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_with_trust)
-    httpserver::webserver ws = httpserver::create_webserver(8080)
+    httpserver::webserver ws = httpserver::create_webserver(PORT)
         .use_ssl()
         .https_mem_key("key.pem")
         .https_mem_cert("cert.pem")
@@ -476,7 +486,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_with_trust)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);  // avoid verifying ssl
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);  // avoid verifying ssl
-    curl_easy_setopt(curl, CURLOPT_URL, "https://localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -498,7 +508,7 @@ void* start_ws_blocking(void* par) {
 }
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, blocking_server)
-    httpserver::webserver ws = httpserver::create_webserver(8080);
+    httpserver::webserver ws = httpserver::create_webserver(PORT);
 
     pthread_t tid;
     pthread_create(&tid, nullptr, start_ws_blocking, reinterpret_cast<void*>(&ws));
@@ -509,7 +519,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, blocking_server)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -526,7 +536,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, blocking_server)
 LT_END_AUTO_TEST(blocking_server)
 
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_error_resources)
-    httpserver::webserver ws = httpserver::create_webserver(8080)
+    httpserver::webserver ws = httpserver::create_webserver(PORT)
         .not_found_resource(not_found_custom)
         .method_not_allowed_resource(not_allowed_custom);
 
@@ -539,7 +549,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_error_resources)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -554,7 +564,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_error_resources)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/not_registered");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/not_registered");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -576,7 +586,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_error_resources)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -47,7 +47,7 @@ using std::shared_ptr;
 
 #define STR2(p) #p
 #define STR(p) STR2(p)
-#define PORTS STR(PORT)
+#define PORT_STRING STR(PORT)
 
 size_t writefunc(void *ptr, size_t size, size_t nmemb, std::string *s) {
     s->append(reinterpret_cast<char*>(ptr), size*nmemb);
@@ -90,7 +90,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, start_stop)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -112,7 +112,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, start_stop)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -134,7 +134,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, start_stop)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -160,7 +160,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ipv6)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
@@ -185,7 +185,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, dual_stack)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
@@ -212,7 +212,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, sweet_kill)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -229,7 +229,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, sweet_kill)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -259,7 +259,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, disable_options)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -287,7 +287,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, enable_options)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -342,7 +342,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, single_resource)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/any/url/works");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/any/url/works");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -399,7 +399,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, tuning_options)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -427,7 +427,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_base)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);  // avoid verifying ssl
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);  // avoid verifying ssl
-    curl_easy_setopt(curl, CURLOPT_URL, "https://localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -457,7 +457,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_with_protocol_priorities)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);  // avoid verifying ssl
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);  // avoid verifying ssl
-    curl_easy_setopt(curl, CURLOPT_URL, "https://localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -486,7 +486,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_with_trust)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);  // avoid verifying ssl
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);  // avoid verifying ssl
-    curl_easy_setopt(curl, CURLOPT_URL, "https://localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -519,7 +519,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, blocking_server)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -549,7 +549,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_error_resources)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -564,7 +564,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_error_resources)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/not_registered");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/not_registered");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -586,7 +586,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_error_resources)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORTS "/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);


### PR DESCRIPTION
Several integration tests require that port 8080 be available. As this is one of the more common alternative HTTP ports, it is likely to be unavailable. A bit of pre-processor hacking allows the build to select a different port if needed.

Another issue is that tests that use `httpserver::file_response` require that the expected path be an actual file. Some build environments (the provoking case is where I need to use [libhttpserver from a Bazel build](https://github.com/bcsgh/bazel_rules/blob/bcsgh/libhttpserver-tests/repositories/BUILD.libhttpserver), which uses a sandbox built from symlinks, and I need to also build and run the test under bazel to ensure that build is *also* correct)

---

*NOTE:* I don't know how to make Codacy/cppcheck happy with the new config `HTTPSERVER_PORT` (it seems to already be fine with the other config: `HTTPSERVER_NO_LOCAL_FS`) . The most useful thing I've found is [this](https://stackoverflow.com/questions/64567248/configurationnotchecked-error-with-cppcheck) but I don't know where to go from there.

Help or suggestions would be appreciated.
