### PR TITLE
Be more explicit about C++ version requierments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ libhttpserver can be used without any dependencies aside from libmicrohttpd.
 
 The minimum versions required are:
 * g++ >= 5.5.0 or clang-3.6
+* C++17 or newer
 * libmicrohttpd >= 0.9.64
 * [Optionally]: for TLS (HTTPS) support, you'll need [libgnutls](http://www.gnutls.org/).
 * [Optionally]: to compile the code-reference, you'll need [doxygen](http://www.doxygen.nl/).

--- a/src/httpserver.hpp
+++ b/src/httpserver.hpp
@@ -21,6 +21,10 @@
 #ifndef SRC_HTTPSERVER_HPP_
 #define SRC_HTTPSERVER_HPP_
 
+#if __cplusplus < 201703L
+#  error("libhttpserver requiers C++17 or later.")
+#endif
+
 #define _HTTPSERVER_HPP_INSIDE_
 
 #include "httpserver/basic_auth_fail_response.hpp"

--- a/src/httpserver.hpp
+++ b/src/httpserver.hpp
@@ -22,7 +22,7 @@
 #define SRC_HTTPSERVER_HPP_
 
 #if __cplusplus < 201703L
-#  error("libhttpserver requiers C++17 or later.")
+#  error("libhttpserver requires C++17 or later.")
 #endif
 
 #define _HTTPSERVER_HPP_INSIDE_


### PR DESCRIPTION
### Description of the Change

Prompted by https://github.com/etr/libhttpserver/issues/295

### Release Notes

- Include the minimum C++ version in README.md
- Make any use of `httpserver.hpp` check the C++ version.