### PR TITLE
Make more robust tests.

### DIFF
--- a/test/integ/authentication.cpp
+++ b/test/integ/authentication.cpp
@@ -99,7 +99,7 @@ LT_BEGIN_AUTO_TEST(authentication_suite, base_auth)
     webserver ws = create_webserver(PORT);
 
     user_pass_resource user_pass;
-    ws.register_resource("base", &user_pass);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &user_pass));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -124,7 +124,7 @@ LT_BEGIN_AUTO_TEST(authentication_suite, base_auth_fail)
     webserver ws = create_webserver(PORT);
 
     user_pass_resource user_pass;
-    ws.register_resource("base", &user_pass);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &user_pass));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -156,7 +156,7 @@ LT_BEGIN_AUTO_TEST(authentication_suite, digest_auth)
         .nonce_nc_size(300);
 
     digest_resource digest;
-    ws.register_resource("base", &digest);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &digest));
     ws.start(false);
 
 #if defined(_WINDOWS)
@@ -196,7 +196,7 @@ LT_BEGIN_AUTO_TEST(authentication_suite, digest_auth_wrong_pass)
         .nonce_nc_size(300);
 
     digest_resource digest;
-    ws.register_resource("base", &digest);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &digest));
     ws.start(false);
 
 #if defined(_WINDOWS)

--- a/test/integ/authentication.cpp
+++ b/test/integ/authentication.cpp
@@ -47,6 +47,16 @@ using httpserver::string_response;
 using httpserver::http_resource;
 using httpserver::http_request;
 
+#ifdef HTTPSERVER_PORT
+#define PORT HTTPSERVER_PORT
+#else
+#define PORT 8080
+#endif  // PORT
+
+#define STR2(p) #p
+#define STR(p) STR2(p)
+#define PORT_STRING STR(PORT)
+
 size_t writefunc(void *ptr, size_t size, size_t nmemb, std::string *s) {
     s->append(reinterpret_cast<char*>(ptr), size*nmemb);
     return size*nmemb;
@@ -86,7 +96,7 @@ LT_BEGIN_SUITE(authentication_suite)
 LT_END_SUITE(authentication_suite)
 
 LT_BEGIN_AUTO_TEST(authentication_suite, base_auth)
-    webserver ws = create_webserver(8080);
+    webserver ws = create_webserver(PORT);
 
     user_pass_resource user_pass;
     ws.register_resource("base", &user_pass);
@@ -98,7 +108,7 @@ LT_BEGIN_AUTO_TEST(authentication_suite, base_auth)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_USERNAME, "myuser");
     curl_easy_setopt(curl, CURLOPT_PASSWORD, "mypass");
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -111,7 +121,7 @@ LT_BEGIN_AUTO_TEST(authentication_suite, base_auth)
 LT_END_AUTO_TEST(base_auth)
 
 LT_BEGIN_AUTO_TEST(authentication_suite, base_auth_fail)
-    webserver ws = create_webserver(8080);
+    webserver ws = create_webserver(PORT);
 
     user_pass_resource user_pass;
     ws.register_resource("base", &user_pass);
@@ -123,7 +133,7 @@ LT_BEGIN_AUTO_TEST(authentication_suite, base_auth_fail)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_USERNAME, "myuser");
     curl_easy_setopt(curl, CURLOPT_PASSWORD, "wrongpass");
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -141,7 +151,7 @@ LT_END_AUTO_TEST(base_auth_fail)
 #ifndef _WINDOWS
 
 LT_BEGIN_AUTO_TEST(authentication_suite, digest_auth)
-    webserver ws = create_webserver(8080)
+    webserver ws = create_webserver(PORT)
         .digest_auth_random("myrandom")
         .nonce_nc_size(300);
 
@@ -164,7 +174,7 @@ LT_BEGIN_AUTO_TEST(authentication_suite, digest_auth)
 #else
     curl_easy_setopt(curl, CURLOPT_USERPWD, "myuser:mypass");
 #endif
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -181,7 +191,7 @@ LT_BEGIN_AUTO_TEST(authentication_suite, digest_auth)
 LT_END_AUTO_TEST(digest_auth)
 
 LT_BEGIN_AUTO_TEST(authentication_suite, digest_auth_wrong_pass)
-    webserver ws = create_webserver(8080)
+    webserver ws = create_webserver(PORT)
         .digest_auth_random("myrandom")
         .nonce_nc_size(300);
 
@@ -204,7 +214,7 @@ LT_BEGIN_AUTO_TEST(authentication_suite, digest_auth_wrong_pass)
 #else
     curl_easy_setopt(curl, CURLOPT_USERPWD, "myuser:wrongpass");
 #endif
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);

--- a/test/integ/ban_system.cpp
+++ b/test/integ/ban_system.cpp
@@ -36,6 +36,16 @@ using httpserver::string_response;
 using httpserver::http_request;
 using httpserver::http::http_utils;
 
+#ifdef HTTPSERVER_PORT
+#define PORT HTTPSERVER_PORT
+#else
+#define PORT 8080
+#endif  // PORT
+
+#define STR2(p) #p
+#define STR(p) STR2(p)
+#define PORT_STRING STR(PORT)
+
 size_t writefunc(void *ptr, size_t size, size_t nmemb, std::string *s) {
     s->append(reinterpret_cast<char*>(ptr), size*nmemb);
     return size*nmemb;
@@ -57,7 +67,7 @@ LT_BEGIN_SUITE(ban_system_suite)
 LT_END_SUITE(ban_system_suite)
 
 LT_BEGIN_AUTO_TEST(ban_system_suite, accept_default_ban_blocks)
-    webserver ws = create_webserver(8080).default_policy(http_utils::ACCEPT);
+    webserver ws = create_webserver(PORT).default_policy(http_utils::ACCEPT);
     ws.start(false);
 
     ok_resource resource;
@@ -69,7 +79,7 @@ LT_BEGIN_AUTO_TEST(ban_system_suite, accept_default_ban_blocks)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -84,7 +94,7 @@ LT_BEGIN_AUTO_TEST(ban_system_suite, accept_default_ban_blocks)
 
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     res = curl_easy_perform(curl);
     LT_ASSERT_NEQ(res, 0);
@@ -97,7 +107,7 @@ LT_BEGIN_AUTO_TEST(ban_system_suite, accept_default_ban_blocks)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -112,7 +122,7 @@ LT_BEGIN_AUTO_TEST(ban_system_suite, accept_default_ban_blocks)
 LT_END_AUTO_TEST(accept_default_ban_blocks)
 
 LT_BEGIN_AUTO_TEST(ban_system_suite, reject_default_allow_passes)
-    webserver ws = create_webserver(8080).default_policy(http_utils::REJECT);
+    webserver ws = create_webserver(PORT).default_policy(http_utils::REJECT);
     ws.start(false);
 
     ok_resource resource;
@@ -123,7 +133,7 @@ LT_BEGIN_AUTO_TEST(ban_system_suite, reject_default_allow_passes)
     {
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     res = curl_easy_perform(curl);
     LT_ASSERT_NEQ(res, 0);
@@ -136,7 +146,7 @@ LT_BEGIN_AUTO_TEST(ban_system_suite, reject_default_allow_passes)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
@@ -151,7 +161,7 @@ LT_BEGIN_AUTO_TEST(ban_system_suite, reject_default_allow_passes)
 
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     res = curl_easy_perform(curl);
     LT_ASSERT_NEQ(res, 0);

--- a/test/integ/ban_system.cpp
+++ b/test/integ/ban_system.cpp
@@ -71,7 +71,7 @@ LT_BEGIN_AUTO_TEST(ban_system_suite, accept_default_ban_blocks)
     ws.start(false);
 
     ok_resource resource;
-    ws.register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &resource));
 
     curl_global_init(CURL_GLOBAL_ALL);
 
@@ -126,7 +126,7 @@ LT_BEGIN_AUTO_TEST(ban_system_suite, reject_default_allow_passes)
     ws.start(false);
 
     ok_resource resource;
-    ws.register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &resource));
 
     curl_global_init(CURL_GLOBAL_ALL);
 

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -349,9 +349,9 @@ LT_END_AUTO_TEST(server_runs)
 
 LT_BEGIN_AUTO_TEST(basic_suite, two_endpoints)
     ok_resource ok;
-    ws->register_resource("OK", &ok);
+    LT_ASSERT_EQ(true, ws->register_resource("OK", &ok));
     nok_resource nok;
-    ws->register_resource("NOK", &nok);
+    LT_ASSERT_EQ(true, ws->register_resource("NOK", &nok));
 
     curl_global_init(CURL_GLOBAL_ALL);
     string s;
@@ -543,7 +543,7 @@ LT_END_AUTO_TEST(overlapping_endpoints)
 
 LT_BEGIN_AUTO_TEST(basic_suite, read_body)
     simple_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     string s;
     CURL *curl = curl_easy_init();
@@ -560,7 +560,7 @@ LT_END_AUTO_TEST(read_body)
 
 LT_BEGIN_AUTO_TEST(basic_suite, read_long_body)
     long_content_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     string s;
     CURL *curl = curl_easy_init();
@@ -577,7 +577,7 @@ LT_END_AUTO_TEST(read_long_body)
 
 LT_BEGIN_AUTO_TEST(basic_suite, resource_setting_header)
     header_set_test_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     string s;
     map<string, string> ss;
@@ -598,7 +598,7 @@ LT_END_AUTO_TEST(resource_setting_header)
 
 LT_BEGIN_AUTO_TEST(basic_suite, resource_setting_cookie)
     cookie_set_test_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     string s;
     CURL *curl = curl_easy_init();
@@ -630,7 +630,7 @@ LT_END_AUTO_TEST(resource_setting_cookie)
 
 LT_BEGIN_AUTO_TEST(basic_suite, request_with_header)
     header_reading_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     string s;
     CURL *curl = curl_easy_init();
@@ -653,7 +653,7 @@ LT_END_AUTO_TEST(request_with_header)
 
 LT_BEGIN_AUTO_TEST(basic_suite, request_with_cookie)
     cookie_reading_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     string s;
     CURL *curl = curl_easy_init();
@@ -671,7 +671,7 @@ LT_END_AUTO_TEST(request_with_cookie)
 
 LT_BEGIN_AUTO_TEST(basic_suite, complete)
     complete_test_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     {
@@ -734,7 +734,7 @@ LT_END_AUTO_TEST(complete)
 
 LT_BEGIN_AUTO_TEST(basic_suite, only_render)
     only_render_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     string s;
     CURL* curl;
@@ -813,7 +813,7 @@ LT_END_AUTO_TEST(only_render)
 
 LT_BEGIN_AUTO_TEST(basic_suite, postprocessor)
     simple_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     string s;
     CURL *curl = curl_easy_init();
@@ -830,7 +830,7 @@ LT_END_AUTO_TEST(postprocessor)
 
 LT_BEGIN_AUTO_TEST(basic_suite, same_key_different_value)
     arg_value_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     string s;
     CURL *curl = curl_easy_init();
@@ -851,7 +851,7 @@ LT_END_AUTO_TEST(same_key_different_value)
 
 LT_BEGIN_AUTO_TEST(basic_suite, same_key_different_value_plain_content)
     arg_value_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     string s;
     CURL *curl = curl_easy_init();
@@ -872,7 +872,7 @@ LT_END_AUTO_TEST(same_key_different_value_plain_content)
 
 LT_BEGIN_AUTO_TEST(basic_suite, empty_arg)
     simple_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     CURL *curl = curl_easy_init();
     CURLcode res;
@@ -886,7 +886,7 @@ LT_END_AUTO_TEST(empty_arg)
 
 LT_BEGIN_AUTO_TEST(basic_suite, no_response)
     no_response_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     CURL* curl = curl_easy_init();
@@ -902,7 +902,7 @@ LT_END_AUTO_TEST(no_response)
 
 LT_BEGIN_AUTO_TEST(basic_suite, empty_response)
     empty_response_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     CURL* curl = curl_easy_init();
@@ -918,7 +918,7 @@ LT_END_AUTO_TEST(empty_response)
 
 LT_BEGIN_AUTO_TEST(basic_suite, regex_matching)
     simple_resource resource;
-    ws->register_resource("regex/matching/number/[0-9]+", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("regex/matching/number/[0-9]+", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -936,7 +936,7 @@ LT_END_AUTO_TEST(regex_matching)
 
 LT_BEGIN_AUTO_TEST(basic_suite, regex_matching_arg)
     args_resource resource;
-    ws->register_resource("this/captures/{arg}/passed/in/input", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("this/captures/{arg}/passed/in/input", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -954,7 +954,7 @@ LT_END_AUTO_TEST(regex_matching_arg)
 
 LT_BEGIN_AUTO_TEST(basic_suite, regex_matching_arg_custom)
     args_resource resource;
-    ws->register_resource("this/captures/numeric/{arg|([0-9]+)}/passed/in/input", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("this/captures/numeric/{arg|([0-9]+)}/passed/in/input", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     {
@@ -991,7 +991,7 @@ LT_END_AUTO_TEST(regex_matching_arg_custom)
 
 LT_BEGIN_AUTO_TEST(basic_suite, querystring_processing)
     args_resource resource;
-    ws->register_resource("this/captures/args/passed/in/the/querystring", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("this/captures/args/passed/in/the/querystring", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1009,7 +1009,7 @@ LT_END_AUTO_TEST(querystring_processing)
 
 LT_BEGIN_AUTO_TEST(basic_suite, full_arguments_processing)
     full_args_resource resource;
-    ws->register_resource("this/captures/args/passed/in/the/querystring", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("this/captures/args/passed/in/the/querystring", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1027,7 +1027,7 @@ LT_END_AUTO_TEST(full_arguments_processing)
 
 LT_BEGIN_AUTO_TEST(basic_suite, querystring_query_processing)
     querystring_resource resource;
-    ws->register_resource("this/captures/args/passed/in/the/querystring", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("this/captures/args/passed/in/the/querystring", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1045,7 +1045,7 @@ LT_END_AUTO_TEST(querystring_query_processing)
 
 LT_BEGIN_AUTO_TEST(basic_suite, register_unregister)
     simple_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     {
@@ -1083,7 +1083,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, register_unregister)
     curl_easy_cleanup(curl);
     }
 
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     {
     string s;
     CURL *curl = curl_easy_init();
@@ -1102,7 +1102,7 @@ LT_END_AUTO_TEST(register_unregister)
 #ifndef HTTPSERVER_NO_LOCAL_FS
 LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource)
     file_response_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1120,7 +1120,7 @@ LT_END_AUTO_TEST(file_serving_resource)
 
 LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_empty)
     file_response_resource_empty resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1138,7 +1138,7 @@ LT_END_AUTO_TEST(file_serving_resource_empty)
 
 LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_default_content_type)
     file_response_resource_default_content_type resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     map<string, string> ss;
@@ -1157,7 +1157,7 @@ LT_END_AUTO_TEST(file_serving_resource_default_content_type)
 
 LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_missing)
     file_response_resource_missing resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1181,7 +1181,7 @@ LT_END_AUTO_TEST(file_serving_resource_missing)
 #ifndef HTTPSERVER_NO_LOCAL_FS
 LT_BEGIN_AUTO_TEST(basic_suite, file_serving_resource_dir)
     file_response_resource_dir resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1205,7 +1205,7 @@ LT_END_AUTO_TEST(file_serving_resource_dir)
 
 LT_BEGIN_AUTO_TEST(basic_suite, exception_forces_500)
     exception_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1228,7 +1228,7 @@ LT_END_AUTO_TEST(exception_forces_500)
 
 LT_BEGIN_AUTO_TEST(basic_suite, untyped_error_forces_500)
     error_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1252,7 +1252,7 @@ LT_END_AUTO_TEST(untyped_error_forces_500)
 LT_BEGIN_AUTO_TEST(basic_suite, request_is_printable)
     stringstream ss;
     print_request_resource resource(&ss);
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1287,7 +1287,7 @@ LT_END_AUTO_TEST(request_is_printable)
 LT_BEGIN_AUTO_TEST(basic_suite, response_is_printable)
     stringstream ss;
     print_response_resource resource(&ss);
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1319,7 +1319,7 @@ LT_END_AUTO_TEST(response_is_printable)
 
 LT_BEGIN_AUTO_TEST(basic_suite, long_path_pieces)
     path_pieces_resource resource;
-    ws->register_resource("/settings", &resource, true);
+    LT_ASSERT_EQ(true, ws->register_resource("/settings", &resource, true));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1337,7 +1337,7 @@ LT_END_AUTO_TEST(long_path_pieces)
 
 LT_BEGIN_AUTO_TEST(basic_suite, url_with_regex_like_pieces)
     path_pieces_resource resource;
-    ws->register_resource("/settings", &resource, true);
+    LT_ASSERT_EQ(true, ws->register_resource("/settings", &resource, true));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1355,7 +1355,7 @@ LT_END_AUTO_TEST(url_with_regex_like_pieces)
 
 LT_BEGIN_AUTO_TEST(basic_suite, non_family_url_with_regex_like_pieces)
     ok_resource resource;
-    ws->register_resource("/settings", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("/settings", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     string s;
@@ -1377,7 +1377,7 @@ LT_END_AUTO_TEST(non_family_url_with_regex_like_pieces)
 
 LT_BEGIN_AUTO_TEST(basic_suite, regex_url_exact_match)
     ok_resource resource;
-    ws->register_resource("/foo/{v|[a-z]}/bar", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("/foo/{v|[a-z]}/bar", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     {
@@ -1426,7 +1426,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, method_not_allowed_header)
     resource.disallow_all();
     resource.set_allowing("POST", true);
     resource.set_allowing("HEAD", true);
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     string s;
     map<string, string> ss;

--- a/test/integ/deferred.cpp
+++ b/test/integ/deferred.cpp
@@ -131,7 +131,7 @@ LT_END_SUITE(deferred_suite)
 
 LT_BEGIN_AUTO_TEST(deferred_suite, deferred_response_suite)
     deferred_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     std::string s;
@@ -149,7 +149,7 @@ LT_END_AUTO_TEST(deferred_response_suite)
 
 LT_BEGIN_AUTO_TEST(deferred_suite, deferred_response_with_data)
     deferred_resource_with_data resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
 
     std::string s;

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -26,6 +26,7 @@
 #include <random>
 #include <sstream>
 #include <string>
+#include <tuple>
 
 #include "./httpserver.hpp"
 #include "httpserver/string_utilities.hpp"

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -48,15 +48,24 @@ using httpserver::webserver;
 using httpserver::create_webserver;
 using httpserver::http::arg_map;
 
+#define STR2(p) #p
+#define STR(p) STR2(p)
+
+#ifdef HTTPSERVER_DATA_ROOT
+#define ROOT STR(HTTPSERVER_DATA_ROOT)
+#else
+#define ROOT "."
+#endif  // HTTPSERVER_DATA_ROOT
+
 static const char* TEST_CONTENT_FILENAME = "test_content";
-static const char* TEST_CONTENT_FILEPATH = "./test_content";
+static const char* TEST_CONTENT_FILEPATH = ROOT "/test_content";
 static const char* FILENAME_IN_GET_CONTENT = "filename=\"test_content\"";
 static const char* TEST_CONTENT = "test content of file\n";
 static const char* TEST_KEY = "file";
 static size_t TEST_CONTENT_SIZE = 21;
 
 static const char* TEST_CONTENT_FILENAME_2 = "test_content_2";
-static const char* TEST_CONTENT_FILEPATH_2 = "./test_content_2";
+static const char* TEST_CONTENT_FILEPATH_2 = ROOT "/test_content_2";
 static const char* FILENAME_IN_GET_CONTENT_2 = "filename=\"test_content_2\"";
 static const char* TEST_CONTENT_2 = "test content of second file\n";
 static const char* TEST_KEY_2 = "file2";
@@ -68,7 +77,7 @@ static const char* TEST_PARAM_VALUE = "Value of test param";
 // The large file test_content_large is large enough to ensure
 // that MHD splits the underlying request into several chunks.
 static const char* LARGE_FILENAME_IN_GET_CONTENT = "filename=\"test_content_large\"";
-static const char* LARGE_CONTENT_FILEPATH = "./test_content_large";
+static const char* LARGE_CONTENT_FILEPATH = ROOT "/test_content_large";
 static const char* LARGE_KEY = "large_file";
 
 static bool file_exists(const string &path) {

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -48,8 +48,15 @@ using httpserver::webserver;
 using httpserver::create_webserver;
 using httpserver::http::arg_map;
 
+#ifdef HTTPSERVER_PORT
+#define PORT HTTPSERVER_PORT
+#else
+#define PORT 8080
+#endif  // PORT
+
 #define STR2(p) #p
 #define STR(p) STR2(p)
+#define PORT_STRING STR(PORT)
 
 #ifdef HTTPSERVER_DATA_ROOT
 #define ROOT STR(HTTPSERVER_DATA_ROOT)
@@ -108,7 +115,7 @@ static std::pair<CURLcode, long> send_file_to_webserver(bool add_second_file, bo
     }
 
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/upload");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/upload");
     curl_easy_setopt(curl, CURLOPT_MIMEPOST, form);
 
     res = curl_easy_perform(curl);
@@ -142,7 +149,7 @@ static std::pair<CURLcode, long> send_large_file(string* content, std::string ar
     curl_mime_name(field, LARGE_KEY);
     curl_mime_filedata(field, LARGE_CONTENT_FILEPATH);
 
-    std::string url = "localhost:8080/upload";
+    std::string url = "localhost:" PORT_STRING "/upload";
     if (!args.empty()) {
         url.append(args);
     }
@@ -183,7 +190,7 @@ static std::tuple<bool, CURLcode, long> send_file_via_put() {
         return {false, CURLcode{}, 0L};
     }
 
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/upload");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/upload");
     curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
     curl_easy_setopt(curl, CURLOPT_READDATA, fd);
     curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t) file_info.st_size);
@@ -271,7 +278,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk)
     string upload_directory = ".";
     webserver* ws;
 
-    ws = new webserver(create_webserver(8080)
+    ws = new webserver(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_AND_DISK)
                        .file_upload_dir(upload_directory)
@@ -321,7 +328,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_via_put)
     string upload_directory = ".";
     webserver* ws;
 
-    ws = new webserver(create_webserver(8080)
+    ws = new webserver(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_AND_DISK)
                        .file_upload_dir(upload_directory)
@@ -354,7 +361,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_additional_par
     string upload_directory = ".";
     webserver* ws;
 
-    ws = new webserver(create_webserver(8080)
+    ws = new webserver(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_AND_DISK)
                        .file_upload_dir(upload_directory)
@@ -409,7 +416,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_two_files)
     string upload_directory = ".";
     webserver* ws;
 
-    ws = new webserver(create_webserver(8080)
+    ws = new webserver(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_AND_DISK)
                        .file_upload_dir(upload_directory)
@@ -479,7 +486,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_disk_only)
     string upload_directory = ".";
     webserver* ws;
 
-    ws = new webserver(create_webserver(8080)
+    ws = new webserver(create_webserver(PORT)
                        .no_put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_DISK_ONLY)
                        .file_upload_dir(upload_directory)
@@ -524,7 +531,7 @@ LT_END_AUTO_TEST(file_upload_disk_only)
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_incl_content)
     webserver* ws;
 
-    ws = new webserver(create_webserver(8080)
+    ws = new webserver(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_ONLY));
     ws->start(false);
@@ -557,7 +564,7 @@ LT_END_AUTO_TEST(file_upload_memory_only_incl_content)
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_large_content)
     webserver* ws;
 
-    ws = new webserver(create_webserver(8080)
+    ws = new webserver(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_ONLY));
     ws->start(false);
@@ -597,7 +604,7 @@ LT_END_AUTO_TEST(file_upload_large_content)
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_large_content_with_args)
     webserver* ws;
 
-    ws = new webserver(create_webserver(8080)
+    ws = new webserver(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_ONLY));
     ws->start(false);
@@ -643,7 +650,7 @@ LT_END_AUTO_TEST(file_upload_large_content_with_args)
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_excl_content)
     webserver* ws;
 
-    ws = new webserver(create_webserver(8080)
+    ws = new webserver(create_webserver(PORT)
                        .no_put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_ONLY));
     ws->start(false);

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -512,7 +512,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_disk_only)
 LT_END_AUTO_TEST(file_upload_disk_only)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_incl_content)
-    string upload_directory = ".";
     webserver* ws;
 
     ws = new webserver(create_webserver(8080)
@@ -546,7 +545,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_incl_content)
 LT_END_AUTO_TEST(file_upload_memory_only_incl_content)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_large_content)
-    string upload_directory = ".";
     webserver* ws;
 
     ws = new webserver(create_webserver(8080)
@@ -587,7 +585,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_large_content)
 LT_END_AUTO_TEST(file_upload_large_content)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_large_content_with_args)
-    string upload_directory = ".";
     webserver* ws;
 
     ws = new webserver(create_webserver(8080)
@@ -634,7 +631,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_large_content_with_args)
 LT_END_AUTO_TEST(file_upload_large_content_with_args)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_excl_content)
-    string upload_directory = ".";
     webserver* ws;
 
     ws = new webserver(create_webserver(8080)

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -21,6 +21,7 @@
 #include <curl/curl.h>
 #include <sys/stat.h>
 #include <cassert>
+#include <cstddef>
 #include <fstream>
 #include <map>
 #include <random>
@@ -93,7 +94,7 @@ static bool file_exists(const string &path) {
     return (stat(path.c_str(), &sb) == 0);
 }
 
-static std::pair<CURLcode, long> send_file_to_webserver(bool add_second_file, bool append_parameters) {
+static std::pair<CURLcode, int32_t> send_file_to_webserver(bool add_second_file, bool append_parameters) {
     curl_global_init(CURL_GLOBAL_ALL);
 
     CURL *curl = curl_easy_init();
@@ -119,7 +120,7 @@ static std::pair<CURLcode, long> send_file_to_webserver(bool add_second_file, bo
     curl_easy_setopt(curl, CURLOPT_MIMEPOST, form);
 
     res = curl_easy_perform(curl);
-    long http_code = 0;
+    long http_code = 0;   // NOLINT [runtime/int]
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
 
     curl_easy_cleanup(curl);
@@ -127,7 +128,7 @@ static std::pair<CURLcode, long> send_file_to_webserver(bool add_second_file, bo
     return {res, http_code};
 }
 
-static std::pair<CURLcode, long> send_large_file(string* content, std::string args = "") {
+static std::pair<CURLcode, int32_t> send_large_file(string* content, std::string args = "") {
     // Generate a large (100K) file of random bytes. Upload the file with
     // a curl request, then delete the file. The default chunk size of MHD
     // appears to be around 16K, so 100K should be enough to trigger the
@@ -158,7 +159,7 @@ static std::pair<CURLcode, long> send_large_file(string* content, std::string ar
     curl_easy_setopt(curl, CURLOPT_MIMEPOST, form);
 
     res = curl_easy_perform(curl);
-    long http_code = 0;
+    long http_code = 0;   // NOLINT [runtime/int]
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
 
     curl_easy_cleanup(curl);
@@ -167,7 +168,7 @@ static std::pair<CURLcode, long> send_large_file(string* content, std::string ar
     return {res, http_code};
 }
 
-static std::tuple<bool, CURLcode, long> send_file_via_put() {
+static std::tuple<bool, CURLcode, int32_t> send_file_via_put() {
     curl_global_init(CURL_GLOBAL_ALL);
 
     CURL *curl;
@@ -196,7 +197,7 @@ static std::tuple<bool, CURLcode, long> send_file_via_put() {
     curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t) file_info.st_size);
 
     res = curl_easy_perform(curl);
-    long http_code = 0;
+    long http_code = 0;   // NOLINT [runtime/int]
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
 
     curl_easy_cleanup(curl);

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -240,6 +240,18 @@ LT_BEGIN_SUITE(file_upload_suite)
     }
 LT_END_SUITE(file_upload_suite)
 
+LT_BEGIN_AUTO_TEST(file_upload_suite, check_files)
+  std::ifstream it;
+  it.open(TEST_CONTENT_FILEPATH);
+  LT_CHECK_EQ(it.is_open(), true);
+
+  it.open(TEST_CONTENT_FILEPATH_2);
+  LT_CHECK_EQ(it.is_open(), true);
+
+  it.open(LARGE_CONTENT_FILEPATH);
+  LT_CHECK_EQ(it.is_open(), true);
+LT_END_AUTO_TEST(check_files)
+
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk)
     string upload_directory = ".";
     webserver* ws;

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -287,7 +287,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk)
     LT_CHECK_EQ(ws->is_running(), true);
 
     print_file_upload_resource resource;
-    ws->register_resource("upload", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("upload", &resource));
 
     auto res = send_file_to_webserver(false, false);
     LT_ASSERT_EQ(res.first, 0);
@@ -337,7 +337,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_via_put)
     LT_CHECK_EQ(ws->is_running(), true);
 
     print_file_upload_resource resource;
-    ws->register_resource("upload", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("upload", &resource));
 
     auto ret = send_file_via_put();
     LT_CHECK_EQ(std::get<1>(ret), 0);
@@ -370,7 +370,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_additional_par
     LT_CHECK_EQ(ws->is_running(), true);
 
     print_file_upload_resource resource;
-    ws->register_resource("upload", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("upload", &resource));
 
     auto res = send_file_to_webserver(false, true);
     LT_ASSERT_EQ(res.first, 0);
@@ -425,7 +425,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_two_files)
     LT_CHECK_EQ(ws->is_running(), true);
 
     print_file_upload_resource resource;
-    ws->register_resource("upload", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("upload", &resource));
 
     auto res = send_file_to_webserver(true, false);
     LT_ASSERT_EQ(res.first, 0);
@@ -495,7 +495,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_disk_only)
     LT_CHECK_EQ(ws->is_running(), true);
 
     print_file_upload_resource resource;
-    ws->register_resource("upload", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("upload", &resource));
 
     auto res = send_file_to_webserver(false, false);
     LT_ASSERT_EQ(res.first, 0);
@@ -538,7 +538,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_incl_content)
     LT_CHECK_EQ(ws->is_running(), true);
 
     print_file_upload_resource resource;
-    ws->register_resource("upload", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("upload", &resource));
 
     auto res = send_file_to_webserver(false, false);
     LT_ASSERT_EQ(res.first, 0);
@@ -571,7 +571,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_large_content)
     LT_CHECK_EQ(ws->is_running(), true);
 
     print_file_upload_resource resource;
-    ws->register_resource("upload", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("upload", &resource));
 
     // Upload a large file to trigger the chunking behavior of MHD.
     std::string file_content;
@@ -611,7 +611,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_large_content_with_args)
     LT_CHECK_EQ(ws->is_running(), true);
 
     print_file_upload_resource resource;
-    ws->register_resource("upload", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("upload", &resource));
 
     // Upload a large file to trigger the chunking behavior of MHD.
     // Include some additional args to make sure those are processed as well.
@@ -657,7 +657,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_excl_content)
     LT_CHECK_EQ(ws->is_running(), true);
 
     print_file_upload_resource resource;
-    ws->register_resource("upload", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("upload", &resource));
 
     auto res = send_file_to_webserver(false, false);
     LT_ASSERT_EQ(res.first, 0);

--- a/test/integ/nodelay.cpp
+++ b/test/integ/nodelay.cpp
@@ -68,7 +68,7 @@ LT_END_SUITE(threaded_suite)
 
 LT_BEGIN_AUTO_TEST(threaded_suite, base)
     ok_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     std::string s;
     CURL* curl;

--- a/test/integ/nodelay.cpp
+++ b/test/integ/nodelay.cpp
@@ -35,6 +35,16 @@ using httpserver::http_resource;
 using httpserver::webserver;
 using httpserver::create_webserver;
 
+#ifdef HTTPSERVER_PORT
+#define PORT HTTPSERVER_PORT
+#else
+#define PORT 8080
+#endif  // PORT
+
+#define STR2(p) #p
+#define STR(p) STR2(p)
+#define PORT_STRING STR(PORT)
+
 class ok_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
@@ -46,7 +56,7 @@ LT_BEGIN_SUITE(threaded_suite)
     webserver* ws;
 
     void set_up() {
-        ws = new webserver(create_webserver(8080).tcp_nodelay());
+        ws = new webserver(create_webserver(PORT).tcp_nodelay());
         ws->start(false);
     }
 
@@ -65,7 +75,7 @@ LT_BEGIN_AUTO_TEST(threaded_suite, base)
     CURLcode res;
 
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);

--- a/test/integ/threaded.cpp
+++ b/test/integ/threaded.cpp
@@ -79,7 +79,7 @@ LT_END_SUITE(threaded_suite)
 LT_BEGIN_AUTO_TEST(threaded_suite, base)
 #ifndef _WINDOWS
     ok_resource resource;
-    ws->register_resource("base", &resource);
+    LT_ASSERT_EQ(true, ws->register_resource("base", &resource));
     curl_global_init(CURL_GLOBAL_ALL);
     std::string s;
     CURL* curl;

--- a/test/integ/threaded.cpp
+++ b/test/integ/threaded.cpp
@@ -38,6 +38,16 @@ using httpserver::string_response;
 using httpserver::webserver;
 using httpserver::create_webserver;
 
+#ifdef HTTPSERVER_PORT
+#define PORT HTTPSERVER_PORT
+#else
+#define PORT 8080
+#endif  // PORT
+
+#define STR2(p) #p
+#define STR(p) STR2(p)
+#define PORT_STRING STR(PORT)
+
 class ok_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
@@ -53,7 +63,7 @@ LT_BEGIN_SUITE(threaded_suite)
 
     void set_up() {
 #ifndef _WINDOWS
-        ws = new webserver(create_webserver(8080).start_method(httpserver::http::http_utils::INTERNAL_SELECT).max_threads(5));
+        ws = new webserver(create_webserver(PORT).start_method(httpserver::http::http_utils::INTERNAL_SELECT).max_threads(5));
         ws->start(false);
 #endif
     }
@@ -76,7 +86,7 @@ LT_BEGIN_AUTO_TEST(threaded_suite, base)
     CURLcode res;
 
     curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8080/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     res = curl_easy_perform(curl);
     LT_ASSERT_EQ(res, 0);

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -312,7 +312,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_socket)
     struct sockaddr_in address;
     address.sin_family = AF_INET;
     address.sin_addr.s_addr = inet_addr("127.0.0.1");
-    address.sin_port = htons(8181);
+    address.sin_port = htons(PORT);
     bind(fd, (struct sockaddr*) &address, sizeof(address));
     listen(fd, 10000);
 
@@ -325,7 +325,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_socket)
     std::string s;
     CURL *curl = curl_easy_init();
     CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "localhost:8181/base");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -89,7 +89,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, start_stop)
     { // NOLINT (internal scope opening - not method start)
     httpserver::webserver ws = httpserver::create_webserver(PORT);
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -111,7 +111,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, start_stop)
     {
     httpserver::webserver ws = httpserver::create_webserver(PORT).start_method(httpserver::http::http_utils::INTERNAL_SELECT);
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -133,7 +133,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, start_stop)
     {
     httpserver::webserver ws = httpserver::create_webserver(PORT).start_method(httpserver::http::http_utils::THREAD_PER_CONNECTION);
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -159,7 +159,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ipv6)
     { // NOLINT (internal scope opening - not method start)
     httpserver::webserver ws = httpserver::create_webserver(PORT).use_ipv6();
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -184,7 +184,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, dual_stack)
     { // NOLINT (internal scope opening - not method start)
     httpserver::webserver ws = httpserver::create_webserver(PORT).use_dual_stack();
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -210,7 +210,7 @@ LT_END_AUTO_TEST(dual_stack)
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, sweet_kill)
     httpserver::webserver ws = httpserver::create_webserver(PORT);
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     {
@@ -258,7 +258,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, disable_options)
         .no_ban_system()
         .no_post_process();
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -286,7 +286,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, enable_options)
         .ban_system()
         .post_process();
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -318,7 +318,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_socket)
 
     httpserver::webserver ws = httpserver::create_webserver(-1).bind_socket(fd);  // whatever port here doesn't matter
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -341,7 +341,7 @@ LT_END_AUTO_TEST(custom_socket)
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, single_resource)
     httpserver::webserver ws = httpserver::create_webserver(PORT).single_resource();
     ok_resource ok;
-    ws.register_resource("/", &ok, true);
+    LT_ASSERT_EQ(true, ws.register_resource("/", &ok, true));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -398,7 +398,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, tuning_options)
         .nonce_nc_size(10);
 
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     LT_CHECK_NOTHROW(ws.start(false));
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -424,7 +424,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_base)
         .https_mem_cert(ROOT "/cert.pem");
 
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -454,7 +454,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_with_protocol_priorities)
         .https_priorities("NORMAL:-MD5");
 
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -483,7 +483,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_with_trust)
         .https_mem_trust(ROOT "/test_root_ca.pem");
 
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     curl_global_init(CURL_GLOBAL_ALL);
@@ -547,7 +547,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, custom_error_resources)
         .method_not_allowed_resource(not_allowed_custom);
 
     ok_resource ok;
-    ws.register_resource("base", &ok);
+    LT_ASSERT_EQ(true, ws.register_resource("base", &ok));
     ws.start(false);
 
     {

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -507,8 +507,8 @@ LT_END_AUTO_TEST(ssl_with_trust)
 void* start_ws_blocking(void* par) {
     httpserver::webserver* ws = (httpserver::webserver*) par;
     ok_resource ok;
-    ws->register_resource("base", &ok);
-    ws->start(true);
+    if (!ws->register_resource("base", &ok)) return PTHREAD_CANCELED;
+    try { ws->start(true); } catch (...) { return PTHREAD_CANCELED; }
 
     return nullptr;
 }
@@ -538,6 +538,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, blocking_server)
 
     char* b;
     pthread_join(tid, reinterpret_cast<void**>(&b));
+    LT_CHECK_EQ(b, nullptr);
     free(b);
 LT_END_AUTO_TEST(blocking_server)
 

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -49,6 +49,12 @@ using std::shared_ptr;
 #define STR(p) STR2(p)
 #define PORT_STRING STR(PORT)
 
+#ifdef HTTPSERVER_DATA_ROOT
+#define ROOT STR(HTTPSERVER_DATA_ROOT)
+#else
+#define ROOT "."
+#endif  // HTTPSERVER_DATA_ROOT
+
 size_t writefunc(void *ptr, size_t size, size_t nmemb, std::string *s) {
     s->append(reinterpret_cast<char*>(ptr), size*nmemb);
     return size*nmemb;
@@ -414,8 +420,8 @@ LT_END_AUTO_TEST(tuning_options)
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_base)
     httpserver::webserver ws = httpserver::create_webserver(PORT)
         .use_ssl()
-        .https_mem_key("key.pem")
-        .https_mem_cert("cert.pem");
+        .https_mem_key(ROOT "/key.pem")
+        .https_mem_cert(ROOT "/cert.pem");
 
     ok_resource ok;
     ws.register_resource("base", &ok);
@@ -443,8 +449,8 @@ LT_END_AUTO_TEST(ssl_base)
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_with_protocol_priorities)
     httpserver::webserver ws = httpserver::create_webserver(PORT)
         .use_ssl()
-        .https_mem_key("key.pem")
-        .https_mem_cert("cert.pem")
+        .https_mem_key(ROOT "/key.pem")
+        .https_mem_cert(ROOT "/cert.pem")
         .https_priorities("NORMAL:-MD5");
 
     ok_resource ok;
@@ -472,9 +478,9 @@ LT_END_AUTO_TEST(ssl_with_protocol_priorities)
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_with_trust)
     httpserver::webserver ws = httpserver::create_webserver(PORT)
         .use_ssl()
-        .https_mem_key("key.pem")
-        .https_mem_cert("cert.pem")
-        .https_mem_trust("test_root_ca.pem");
+        .https_mem_key(ROOT "/key.pem")
+        .https_mem_cert(ROOT "/cert.pem")
+        .https_mem_trust(ROOT "/test_root_ca.pem");
 
     ok_resource ok;
     ws.register_resource("base", &ok);

--- a/test/littletest.hpp
+++ b/test/littletest.hpp
@@ -159,7 +159,8 @@
     if((__lt_a__) __lt_op__ (__lt_b__)) \
     { \
         std::stringstream __lt_ss__; \
-        __lt_ss__ << "(" << __lt_file__ << ":" << __lt_line__ << ") - error in " << "\"" << __lt_name__ << "\": " << (__lt_a__) << #__lt_op__ << (__lt_b__); \
+        __lt_ss__ << "(" << __lt_file__ << ":" << __lt_line__ << ") - error in " << "\"" << __lt_name__ << "\": " \
+                  << ::littletest::make_streamable(__lt_a__) << #__lt_op__ << ::littletest::make_streamable(__lt_b__); \
         LT_SWITCH_MODE(__lt_mode__) \
     }
 
@@ -269,12 +270,16 @@
 #define LT_ASSERT_COLLECTIONS_NEQ(__lt_first_begin__, __lt_first_end__, __lt_second_begin__) LT_COLLNEQ_EV((__lt_first_begin__), (__lt_first_end__), (__lt_second_begin__), ASSERT)
 
 #define LT_FAIL(__lt_message__) \
-    std::cout << "[ASSERT FAILURE] (" << __FILE__ << ":" << __LINE__ << ") - error in " << "\"" << (__lt_name__) << "\": " << (__lt_message__) << std::endl; \
+    std::cout << "[ASSERT FAILURE] (" << __FILE__ << ":" << __LINE__ << ") - error in " << "\"" << (__lt_name__) << "\": " \
+              << ::littletest::make_streamable(__lt_message__) << std::endl; \
     __lt_tr__->add_failure(); \
     throw littletest::assert_unattended("");
 
 namespace littletest
 {
+// Special case logging of types that don't print well.
+template<class T> const T& make_streamable(const T& v) { return v; }
+const char* make_streamable(std::nullptr_t) { return "nullptr"; }
 
 struct check_unattended : public std::exception
 {

--- a/test/unit/http_utils_test.cpp
+++ b/test/unit/http_utils_test.cpp
@@ -38,6 +38,15 @@
 using std::string;
 using std::vector;
 
+#define STR2(p) #p
+#define STR(p) STR2(p)
+
+#ifdef HTTPSERVER_DATA_ROOT
+#define ROOT STR(HTTPSERVER_DATA_ROOT)
+#else
+#define ROOT "."
+#endif  // HTTPSERVER_DATA_ROOT
+
 LT_BEGIN_SUITE(http_utils_suite)
     void set_up() {
     }
@@ -548,7 +557,7 @@ LT_BEGIN_AUTO_TEST(http_utils_suite, ip_representation6_sockaddr)
 LT_END_AUTO_TEST(ip_representation6_sockaddr)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, load_file)
-    LT_CHECK_EQ(httpserver::http::load_file("test_content"), "test content of file\n");
+    LT_CHECK_EQ(httpserver::http::load_file(ROOT "/test_content"), "test content of file\n");
 LT_END_AUTO_TEST(load_file)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, load_file_invalid)


### PR DESCRIPTION
This is "more of the same" with regards to making the tests more robust about the environment they are run in.

- Apply the `HTTPSERVER_PORT` patch everywhere.
- Do the same pattern for `HTTPSERVER_DATA_ROOT` for loading test files.
- Add some tests for things that silently failed and showed up while debugging some of the above tweaks.
- Add some tests for things that didn't cause the above but could have been issues.
- Some misc cleanup. 