### PR TITLE
Install libgnutls within the CI flow

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -375,6 +375,11 @@ jobs:
         sudo apt-get install cppcheck ;
       if: ${{ matrix.os-type == 'ubuntu' }}
 
+    - name: Setup gnutls dependency (only on linux)
+      run: |
+        sudo apt-get install libgnutls28-dev ;
+      if: ${{ matrix.os-type == 'ubuntu' }}
+
     - name: Fetch libmicrohttpd from cache
       id: cache-libmicrohttpd
       uses: actions/cache@v2
@@ -384,7 +389,6 @@ jobs:
 
     - name: Build libmicrohttpd dependency (if not cached)
       run: |
-        sudo apt-get install libgnutls28-dev ;
         curl https://s3.amazonaws.com/libhttpserver/libmicrohttpd_releases/libmicrohttpd-0.9.64.tar.gz -o libmicrohttpd-0.9.64.tar.gz ;
         tar -xzf libmicrohttpd-0.9.64.tar.gz ;
         cd libmicrohttpd-0.9.64 ;

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -384,6 +384,7 @@ jobs:
 
     - name: Build libmicrohttpd dependency (if not cached)
       run: |
+        sudo apt-get install libgnutls28-dev ;
         curl https://s3.amazonaws.com/libhttpserver/libmicrohttpd_releases/libmicrohttpd-0.9.64.tar.gz -o libmicrohttpd-0.9.64.tar.gz ;
         tar -xzf libmicrohttpd-0.9.64.tar.gz ;
         cd libmicrohttpd-0.9.64 ;

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -445,7 +445,7 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, ssl_with_protocol_priorities)
         .use_ssl()
         .https_mem_key("key.pem")
         .https_mem_cert("cert.pem")
-        .https_priorities("NONE:+VERS-TLS1.0:+AES-128-CBC:+SHA1:+RSA:+COMP-NULL");
+        .https_priorities("NONE:+AES-256-GCM:+SHA384");
 
     ok_resource ok;
     ws.register_resource("base", &ok);


### PR DESCRIPTION
### Identify the Bug

CI appears to be building libmicrohttpd without SSL dependencies

### Description of the Change

Installig the dependency as part of the CI process.

### Alternate Designs

N/D

### Possible Drawbacks

Marginally slower CI.

### Verification Process

The CI process itself
