### PR TITLE
Count (unexpected) escaping exceptions as a test failure.

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -371,14 +371,13 @@ jobs:
     - name: Setup dependencies (only on linux)
       run: |
         sudo apt-get install info install-info ;
-        sudo pip install gcovr ;
         sudo apt-get install cppcheck ;
       if: ${{ matrix.os-type == 'ubuntu' }}
 
     - name: Setup coverage dependencies (only on linux)
       run: |
         sudo pip install gcovr ;
-      if: ${{ matrix.os-type == 'ubuntu' && matrix.c-compiler == 'gcc' && matrix.debug == 'debug' && matrix.coverage == 'coverage' && success() }}
+      if: ${{ matrix.os-type == 'ubuntu' && matrix.c-compiler == 'gcc' && matrix.debug == 'debug' && matrix.coverage == 'coverage' }}
 
     - name: Setup gnutls dependency (only on linux)
       run: |

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -368,12 +368,17 @@ jobs:
       run: brew install autoconf automake libtool
       if: ${{ matrix.os == 'macos-latest' }}
 
-    - name: Setup coverage dependencies (only on linux)
+    - name: Setup dependencies (only on linux)
       run: |
         sudo apt-get install info install-info ;
         sudo pip install gcovr ;
         sudo apt-get install cppcheck ;
       if: ${{ matrix.os-type == 'ubuntu' }}
+
+    - name: Setup coverage dependencies (only on linux)
+      run: |
+        sudo pip install gcovr ;
+      if: ${{ matrix.os-type == 'ubuntu' && matrix.c-compiler == 'gcc' && matrix.debug == 'debug' && matrix.coverage == 'coverage' && success() }}
 
     - name: Setup gnutls dependency (only on linux)
       run: |

--- a/test/littletest.hpp
+++ b/test/littletest.hpp
@@ -524,10 +524,12 @@ class test : public test_base
             {
                 std::cout << "Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " set up" << std::endl;
                 std::cout << e.what() << std::endl;
+                tr->add_failure();
             }
             catch(...)
             {
                 std::cout << "Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " set up" << std::endl;
+                tr->add_failure();
             }
             try
             {
@@ -544,12 +546,14 @@ class test : public test_base
                 std::cout << e.what() << std::endl;
                 if(tr->last_checkpoint_line != -1)
                     std::cout << "Last checkpoint in " << tr->last_checkpoint_file << ":" << tr->last_checkpoint_line << std::endl;
+                tr->add_failure();
             }
             catch(...)
             {
                 std::cout << "Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " run" << std::endl;
                 if(tr->last_checkpoint_line != -1)
                     std::cout << "Last checkpoint in " << tr->last_checkpoint_file << ":" << tr->last_checkpoint_line << std::endl;
+                tr->add_failure();
             }
             gettimeofday(&after, NULL);
 
@@ -571,10 +575,12 @@ class test : public test_base
             {
                 std::cout << "Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " tear down" << std::endl;
                 std::cout << e.what() << std::endl;
+                tr->add_failure();
             }
             catch(...)
             {
                 std::cout << "Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " tear down" << std::endl;
+                tr->add_failure();
             }
             double total = set_up_duration + test_duration + tear_down_duration;
             tr->add_total_time(total);

--- a/test/littletest.hpp
+++ b/test/littletest.hpp
@@ -125,6 +125,13 @@
     { \
         (__lt_operation__) ;\
     } \
+    catch(std::exception& e) \
+    { \
+        std::stringstream __lt_ss__; \
+        __lt_ss__ << "(" << __lt_file__ << ":" << __lt_line__ << ") - error in " << "\"" << __lt_name__ << "\": exceptions thown by " << #__lt_operation__; \
+        __lt_ss__ << " [ " << e.what() << " ]"; \
+        LT_SWITCH_MODE(__lt_mode__) \
+    } \
     catch(...) \
     { \
         std::stringstream __lt_ss__; \

--- a/test/littletest.hpp
+++ b/test/littletest.hpp
@@ -522,13 +522,13 @@ class test : public test_base
             }
             catch(std::exception& e)
             {
-                std::cout << "Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " set up" << std::endl;
+                std::cout << "[FAILURE] Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " set up" << std::endl;
                 std::cout << e.what() << std::endl;
                 tr->add_failure();
             }
             catch(...)
             {
-                std::cout << "Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " set up" << std::endl;
+                std::cout << "[FAILURE] Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " set up" << std::endl;
                 tr->add_failure();
             }
             try
@@ -542,7 +542,7 @@ class test : public test_base
             }
             catch(std::exception& e)
             {
-                std::cout << "Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " run" << std::endl;
+                std::cout << "[FAILURE] Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " run" << std::endl;
                 std::cout << e.what() << std::endl;
                 if(tr->last_checkpoint_line != -1)
                     std::cout << "Last checkpoint in " << tr->last_checkpoint_file << ":" << tr->last_checkpoint_line << std::endl;
@@ -550,7 +550,7 @@ class test : public test_base
             }
             catch(...)
             {
-                std::cout << "Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " run" << std::endl;
+                std::cout << "[FAILURE] Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " run" << std::endl;
                 if(tr->last_checkpoint_line != -1)
                     std::cout << "Last checkpoint in " << tr->last_checkpoint_file << ":" << tr->last_checkpoint_line << std::endl;
                 tr->add_failure();
@@ -573,13 +573,13 @@ class test : public test_base
             }
             catch(std::exception& e)
             {
-                std::cout << "Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " tear down" << std::endl;
+                std::cout << "[FAILURE] Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " tear down" << std::endl;
                 std::cout << e.what() << std::endl;
                 tr->add_failure();
             }
             catch(...)
             {
-                std::cout << "Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " tear down" << std::endl;
+                std::cout << "[FAILURE] Exception during " << static_cast<test_impl* >(this)->__lt_name__ << " tear down" << std::endl;
                 tr->add_failure();
             }
             double total = set_up_duration + test_duration + tear_down_duration;


### PR DESCRIPTION
### Issue or RFC Endorsed by Maintainers

https://github.com/etr/liblittletest/issues/3

### Description of the Change

Make LittleTest count exceptions escaping from any of the set-up, tear-down or test-run (other than asserts) as a test failure. 

### Alternate Designs

None, considered.

### Possible Drawbacks

This could cause existing test to start failing, But (fingers crossed) that's only likely for test that should already be failing.

### Verification Process

- Ran the `libhttperver` tests and found another cases I didn't already know about that was failing for me.
- The CI for this PR fails as a result of a pre-existing silent error.

### Release Notes

Make LittleTest count exceptions escaping from any of the set-up, tear-down or test-run (other than asserts) as a test failure. 

### See also:

- https://github.com/etr/liblittletest/pull/4