### PR TITLE
Replace new/delete with RAII.

### DIFF
--- a/src/http_resource.cpp
+++ b/src/http_resource.cpp
@@ -21,6 +21,7 @@
 #include "httpserver/http_resource.hpp"
 #include <microhttpd.h>
 #include <iosfwd>
+#include <memory>
 #include "httpserver/string_response.hpp"
 
 namespace httpserver { class http_response; }
@@ -43,7 +44,7 @@ void resource_init(std::map<std::string, bool>* method_state) {
 namespace details {
 
 std::shared_ptr<http_response> empty_render(const http_request&) {
-    return std::shared_ptr<http_response>(new string_response());
+    return std::make_shared<string_response>();
 }
 
 }  // namespace details

--- a/src/httpserver/details/modded_request.hpp
+++ b/src/httpserver/details/modded_request.hpp
@@ -37,7 +37,7 @@ namespace details {
 
 struct modded_request {
     struct MHD_PostProcessor *pp = nullptr;
-    std::string* complete_uri = nullptr;
+    std::unique_ptr<std::string> complete_uri;
     std::unique_ptr<std::string> standardized_url;
     webserver* ws = nullptr;
 
@@ -67,7 +67,6 @@ struct modded_request {
         if (second) {
             delete dhr;
         }
-        delete complete_uri;
     }
 };
 

--- a/src/httpserver/details/modded_request.hpp
+++ b/src/httpserver/details/modded_request.hpp
@@ -50,7 +50,7 @@ struct modded_request {
 
     std::string upload_key;
     std::string upload_filename;
-    std::ofstream* upload_ostrm = nullptr;
+    std::unique_ptr<std::ofstream> upload_ostrm;
 
     modded_request() = default;
 
@@ -69,7 +69,6 @@ struct modded_request {
         }
         delete complete_uri;
         delete standardized_url;
-        delete upload_ostrm;
     }
 };
 

--- a/src/httpserver/details/modded_request.hpp
+++ b/src/httpserver/details/modded_request.hpp
@@ -45,7 +45,6 @@ struct modded_request {
 
     std::unique_ptr<http_request> dhr = nullptr;
     std::shared_ptr<http_response> dhrs;
-    bool second = false;
     bool has_body = false;
 
     std::string upload_key;

--- a/src/httpserver/details/modded_request.hpp
+++ b/src/httpserver/details/modded_request.hpp
@@ -38,7 +38,7 @@ namespace details {
 struct modded_request {
     struct MHD_PostProcessor *pp = nullptr;
     std::string* complete_uri = nullptr;
-    std::string* standardized_url = nullptr;
+    std::unique_ptr<std::string> standardized_url;
     webserver* ws = nullptr;
 
     std::shared_ptr<http_response> (httpserver::http_resource::*callback)(const httpserver::http_request&);
@@ -68,7 +68,6 @@ struct modded_request {
             delete dhr;
         }
         delete complete_uri;
-        delete standardized_url;
     }
 };
 

--- a/src/httpserver/details/modded_request.hpp
+++ b/src/httpserver/details/modded_request.hpp
@@ -43,7 +43,7 @@ struct modded_request {
 
     std::shared_ptr<http_response> (httpserver::http_resource::*callback)(const httpserver::http_request&);
 
-    http_request* dhr = nullptr;
+    std::unique_ptr<http_request> dhr = nullptr;
     std::shared_ptr<http_response> dhrs;
     bool second = false;
     bool has_body = false;
@@ -63,9 +63,6 @@ struct modded_request {
     ~modded_request() {
         if (nullptr != pp) {
             MHD_destroy_post_processor(pp);
-        }
-        if (second) {
-            delete dhr;
         }
     }
 };

--- a/src/httpserver/details/modded_request.hpp
+++ b/src/httpserver/details/modded_request.hpp
@@ -54,10 +54,10 @@ struct modded_request {
 
     modded_request() = default;
 
-    modded_request(const modded_request& b) = default;
+    modded_request(const modded_request& b) = delete;
     modded_request(modded_request&& b) = default;
 
-    modded_request& operator=(const modded_request& b) = default;
+    modded_request& operator=(const modded_request& b) = delete;
     modded_request& operator=(modded_request&& b) = default;
 
     ~modded_request() {

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -252,6 +252,8 @@ class http_request {
 
      friend std::ostream &operator<< (std::ostream &os, http_request &r);
 
+     ~http_request();
+
  private:
      /**
       * Default constructor of the class. It is a specific responsibility of apis to initialize this type of objects.
@@ -285,8 +287,6 @@ class http_request {
      **/
      http_request& operator=(const http_request& b) = delete;
      http_request& operator=(http_request&& b) = default;
-
-     ~http_request();
 
      std::string path;
      std::string method;

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -420,7 +420,6 @@ void* uri_log(void* cls, const char* uri) {
 
     auto mr = std::make_unique<details::modded_request>();
     mr->complete_uri = std::make_unique<string>(uri);
-    mr->second = false;
     return reinterpret_cast<void*>(mr.release());
 }
 
@@ -566,7 +565,6 @@ std::shared_ptr<http_response> webserver::internal_error_page(details::modded_re
 }
 
 MHD_Result webserver::requests_answer_first_step(MHD_Connection* connection, struct details::modded_request* mr) {
-    mr->second = true;
     mr->dhr.reset(new http_request(connection, unescaper));
 
     if (!mr->has_body) {
@@ -743,7 +741,7 @@ MHD_Result webserver::answer_to_connection(void* cls, MHD_Connection* connection
         const char* version, const char* upload_data, size_t* upload_data_size, void** con_cls) {
     struct details::modded_request* mr = static_cast<struct details::modded_request*>(*con_cls);
 
-    if (mr->second != false) {
+    if (mr->dhr) {
         return static_cast<webserver*>(cls)->requests_answer_second_step(connection, method, version, upload_data, upload_data_size, mr);
     }
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -550,7 +550,7 @@ std::shared_ptr<http_response> webserver::not_found_page(details::modded_request
     if (not_found_resource != nullptr) {
         return not_found_resource(*mr->dhr);
     } else {
-        return std::shared_ptr<http_response>(new string_response(NOT_FOUND_ERROR, http_utils::http_not_found));
+        return std::make_shared<string_response>(NOT_FOUND_ERROR, http_utils::http_not_found);
     }
 }
 
@@ -558,7 +558,7 @@ std::shared_ptr<http_response> webserver::method_not_allowed_page(details::modde
     if (method_not_allowed_resource != nullptr) {
         return method_not_allowed_resource(*mr->dhr);
     } else {
-        return std::shared_ptr<http_response>(new string_response(METHOD_ERROR, http_utils::http_method_not_allowed));
+        return std::make_shared<string_response>(METHOD_ERROR, http_utils::http_method_not_allowed);
     }
 }
 
@@ -566,7 +566,7 @@ std::shared_ptr<http_response> webserver::internal_error_page(details::modded_re
     if (internal_error_resource != nullptr && !force_our) {
         return internal_error_resource(*mr->dhr);
     } else {
-        return std::shared_ptr<http_response>(new string_response(GENERIC_ERROR, http_utils::http_internal_server_error, "text/plain"));
+        return std::make_shared<string_response>(GENERIC_ERROR, http_utils::http_internal_server_error);
     }
 }
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -517,8 +517,7 @@ MHD_Result webserver::post_iterator(void *cls, enum MHD_ValueKind kind,
             if (mr->upload_ostrm == nullptr || !mr->upload_ostrm->is_open()) {
                 mr->upload_key = key;
                 mr->upload_filename = filename;
-                delete mr->upload_ostrm;
-                mr->upload_ostrm = new std::ofstream();
+                mr->upload_ostrm = std::make_unique<std::ofstream>();
                 mr->upload_ostrm->open(file.get_file_system_file_name(), std::ios::binary | std::ios::app);
             }
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -182,11 +182,7 @@ void webserver::request_completed(void *cls, struct MHD_Connection *connection, 
     std::ignore = connection;
     std::ignore = toe;
 
-    details::modded_request* mr = static_cast<details::modded_request*>(*con_cls);
-    if (mr == nullptr) return;
-
-    delete mr;
-    mr = nullptr;
+    delete static_cast<details::modded_request*>(*con_cls);
 }
 
 bool webserver::register_resource(const std::string& resource, http_resource* hrm, bool family) {
@@ -422,10 +418,10 @@ void* uri_log(void* cls, const char* uri) {
     // Parameter needed to respect MHD interface, but not needed here.
     std::ignore = cls;
 
-    struct details::modded_request* mr = new details::modded_request();
+    auto mr = std::make_unique<details::modded_request>();
     mr->complete_uri = new string(uri);
     mr->second = false;
-    return reinterpret_cast<void*>(mr);
+    return reinterpret_cast<void*>(mr.release());
 }
 
 void error_log(void* cls, const char* fmt, va_list ap) {

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -757,7 +757,7 @@ MHD_Result webserver::answer_to_connection(void* cls, MHD_Connection* connection
     std::string t_url = url;
 
     base_unescaper(&t_url, static_cast<webserver*>(cls)->unescaper);
-    mr->standardized_url = new string(http_utils::standardize_url(t_url));
+    mr->standardized_url = std::make_unique<std::string>(http_utils::standardize_url(t_url));
 
     mr->has_body = false;
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -419,7 +419,7 @@ void* uri_log(void* cls, const char* uri) {
     std::ignore = cls;
 
     auto mr = std::make_unique<details::modded_request>();
-    mr->complete_uri = new string(uri);
+    mr->complete_uri = std::make_unique<string>(uri);
     mr->second = false;
     return reinterpret_cast<void*>(mr.release());
 }

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -567,7 +567,7 @@ std::shared_ptr<http_response> webserver::internal_error_page(details::modded_re
 
 MHD_Result webserver::requests_answer_first_step(MHD_Connection* connection, struct details::modded_request* mr) {
     mr->second = true;
-    mr->dhr = new http_request(connection, unescaper);
+    mr->dhr.reset(new http_request(connection, unescaper));
 
     if (!mr->has_body) {
         return MHD_YES;

--- a/test/integ/authentication.cpp
+++ b/test/integ/authentication.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include <curl/curl.h>
+#include <memory>
 
 #include "./httpserver.hpp"
 #include "./littletest.hpp"
@@ -66,9 +67,9 @@ class user_pass_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request& req) {
          if (req.get_user() != "myuser" || req.get_pass() != "mypass") {
-             return shared_ptr<basic_auth_fail_response>(new basic_auth_fail_response("FAIL", "examplerealm"));
+             return std::make_shared<basic_auth_fail_response>("FAIL", "examplerealm");
          }
-         return shared_ptr<string_response>(new string_response(std::string(req.get_user()) + " " + std::string(req.get_pass()), 200, "text/plain"));
+         return std::make_shared<string_response>(std::string(req.get_user()) + " " + std::string(req.get_pass()), 200, "text/plain");
      }
 };
 
@@ -76,14 +77,14 @@ class digest_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request& req) {
          if (req.get_digested_user() == "") {
-             return shared_ptr<digest_auth_fail_response>(new digest_auth_fail_response("FAIL", "examplerealm", MY_OPAQUE, true));
+             return std::make_shared<digest_auth_fail_response>("FAIL", "examplerealm", MY_OPAQUE, true);
          } else {
              bool reload_nonce = false;
              if (!req.check_digest_auth("examplerealm", "mypass", 300, &reload_nonce)) {
-                 return shared_ptr<digest_auth_fail_response>(new digest_auth_fail_response("FAIL", "examplerealm", MY_OPAQUE, reload_nonce));
+                 return std::make_shared<digest_auth_fail_response>("FAIL", "examplerealm", MY_OPAQUE, reload_nonce);
              }
          }
-         return shared_ptr<string_response>(new string_response("SUCCESS", 200, "text/plain"));
+         return std::make_shared<string_response>("SUCCESS", 200, "text/plain");
      }
 };
 

--- a/test/integ/ban_system.cpp
+++ b/test/integ/ban_system.cpp
@@ -20,6 +20,7 @@
 
 #include <curl/curl.h>
 #include <map>
+#include <memory>
 #include <string>
 
 #include "./httpserver.hpp"
@@ -54,7 +55,7 @@ size_t writefunc(void *ptr, size_t size, size_t nmemb, std::string *s) {
 class ok_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 };
 

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -20,6 +20,7 @@
 
 #include <curl/curl.h>
 #include <map>
+#include <memory>
 #include <numeric>
 #include <sstream>
 #include <string>
@@ -61,17 +62,17 @@ size_t headerfunc(void *ptr, size_t size, size_t nmemb, map<string, string>* ss)
 class simple_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
      shared_ptr<http_response> render_POST(const http_request& req) {
-         return shared_ptr<string_response>(new string_response(std::string(req.get_arg("arg1")) + std::string(req.get_arg("arg2")), 200, "text/plain"));
+         return std::make_shared<string_response>(std::string(req.get_arg("arg1")) + std::string(req.get_arg("arg2")), 200, "text/plain");
      }
 };
 
 class arg_value_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
      shared_ptr<http_response> render_POST(const http_request& req) {
          auto const arg_value = req.get_arg("arg").get_all_values();
@@ -81,28 +82,28 @@ class arg_value_resource : public http_resource {
          std::string all_values = std::accumulate(std::next(arg_value.begin()), arg_value.end(), std::string(arg_value[0]), [](std::string a, std::string_view in) {
             return std::move(a) + std::string(in);
          });
-         return shared_ptr<string_response>(new string_response(all_values, 200, "text/plain"));
+         return std::make_shared<string_response>(all_values, 200, "text/plain");
      }
 };
 
 class args_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request& req) {
-         return shared_ptr<string_response>(new string_response(std::string(req.get_arg("arg")) + std::string(req.get_arg("arg2")), 200, "text/plain"));
+         return std::make_shared<string_response>(std::string(req.get_arg("arg")) + std::string(req.get_arg("arg2")), 200, "text/plain");
      }
 };
 
 class long_content_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<string_response>(new string_response(lorem_ipsum, 200, "text/plain"));
+         return std::make_shared<string_response>(lorem_ipsum, 200, "text/plain");
      }
 };
 
 class header_set_test_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         shared_ptr<string_response> hrb(new string_response("OK", 200, "text/plain"));
+         auto hrb = std::make_shared<string_response>("OK", 200, "text/plain");
          hrb->with_header("KEY", "VALUE");
          return hrb;
      }
@@ -111,7 +112,7 @@ class header_set_test_resource : public http_resource {
 class cookie_set_test_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         shared_ptr<string_response> hrb(new string_response("OK", 200, "text/plain"));
+         auto hrb = std::make_shared<string_response>("OK", 200, "text/plain");
          hrb->with_cookie("MyCookie", "CookieValue");
          return hrb;
      }
@@ -120,28 +121,28 @@ class cookie_set_test_resource : public http_resource {
 class cookie_reading_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request& req) {
-         return shared_ptr<string_response>(new string_response(std::string(req.get_cookie("name")), 200, "text/plain"));
+         return std::make_shared<string_response>(std::string(req.get_cookie("name")), 200, "text/plain");
      }
 };
 
 class header_reading_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request& req) {
-         return shared_ptr<string_response>(new string_response(std::string(req.get_header("MyHeader")), 200, "text/plain"));
+         return std::make_shared<string_response>(std::string(req.get_header("MyHeader")), 200, "text/plain");
      }
 };
 
 class full_args_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request& req) {
-         return shared_ptr<string_response>(new string_response(std::string(req.get_args().at("arg")), 200, "text/plain"));
+         return std::make_shared<string_response>(std::string(req.get_args().at("arg")), 200, "text/plain");
      }
 };
 
 class querystring_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request& req) {
-         return shared_ptr<string_response>(new string_response(std::string(req.get_querystring()), 200, "text/plain"));
+         return std::make_shared<string_response>(std::string(req.get_querystring()), 200, "text/plain");
      }
 };
 
@@ -152,55 +153,55 @@ class path_pieces_resource : public http_resource {
          for (unsigned int i = 0; i < req.get_path_pieces().size(); i++) {
              ss << req.get_path_piece(i) << ",";
          }
-         return shared_ptr<string_response>(new string_response(ss.str(), 200, "text/plain"));
+         return std::make_shared<string_response>(ss.str(), 200, "text/plain");
      }
 };
 
 class complete_test_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 
      shared_ptr<http_response> render_POST(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 
      shared_ptr<http_response> render_PUT(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 
      shared_ptr<http_response> render_DELETE(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 
      shared_ptr<http_response> render_CONNECT(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 
      shared_ptr<http_response> render_PATCH(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 };
 
 class only_render_resource : public http_resource {
  public:
      shared_ptr<http_response> render(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 };
 
 class ok_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 };
 
 class nok_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<string_response>(new string_response("NOK", 200, "text/plain"));
+         return std::make_shared<string_response>("NOK", 200, "text/plain");
      }
 };
 
@@ -209,7 +210,7 @@ class static_resource : public http_resource {
      explicit static_resource(std::string r) : resp(std::move(r)) {}
 
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<string_response>(new string_response(resp, 200, "text/plain"));
+         return std::make_shared<string_response>(resp, 200, "text/plain");
      }
 
      std::string resp;
@@ -218,7 +219,7 @@ class static_resource : public http_resource {
 class no_response_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<http_response>(new http_response());
+         return std::make_shared<http_response>();
      }
 };
 
@@ -233,21 +234,21 @@ class empty_response_resource : public http_resource {
 class file_response_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<file_response>(new file_response("test_content", 200, "text/plain"));
+         return std::make_shared<file_response>("test_content", 200, "text/plain");
      }
 };
 
 class file_response_resource_empty : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<file_response>(new file_response("test_content_empty", 200, "text/plain"));
+         return std::make_shared<file_response>("test_content_empty", 200, "text/plain");
      }
 };
 
 class file_response_resource_default_content_type : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<file_response>(new file_response("test_content", 200));
+         return std::make_shared<file_response>("test_content", 200);
      }
 };
 #endif  // HTTPSERVER_NO_LOCAL_FS
@@ -255,7 +256,7 @@ class file_response_resource_default_content_type : public http_resource {
 class file_response_resource_missing : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<file_response>(new file_response("missing", 200));
+         return std::make_shared<file_response>("missing", 200);
      }
 };
 
@@ -263,7 +264,7 @@ class file_response_resource_missing : public http_resource {
 class file_response_resource_dir : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<file_response>(new file_response("integ", 200));
+         return std::make_shared<file_response>("integ", 200);
      }
 };
 #endif  // HTTPSERVER_NO_LOCAL_FS
@@ -290,7 +291,7 @@ class print_request_resource : public http_resource {
 
      shared_ptr<http_response> render_GET(const http_request& req) {
          (*ss) << req;
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 
  private:
@@ -304,7 +305,7 @@ class print_response_resource : public http_resource {
      }
 
      shared_ptr<http_response> render_GET(const http_request&) {
-         shared_ptr<string_response> hresp(new string_response("OK", 200, "text/plain"));
+         auto hresp = std::make_shared<string_response>("OK", 200, "text/plain");
 
          hresp->with_header("MyResponseHeader", "MyResponseHeaderValue");
          hresp->with_footer("MyResponseFooter", "MyResponseFooterValue");
@@ -330,16 +331,15 @@ class print_response_resource : public http_resource {
 #define PORT_STRING STR(PORT)
 
 LT_BEGIN_SUITE(basic_suite)
-    webserver* ws;
+    std::unique_ptr<webserver> ws;
 
     void set_up() {
-        ws = new webserver(create_webserver(PORT));
+        ws = std::make_unique<webserver>(create_webserver(PORT));
         ws->start(false);
     }
 
     void tear_down() {
         ws->stop();
-        delete ws;
     }
 LT_END_SUITE(basic_suite)
 

--- a/test/integ/deferred.cpp
+++ b/test/integ/deferred.cpp
@@ -31,11 +31,11 @@
 #endif
 
 #include <curl/curl.h>
-#include <memory>
 #include <signal.h>
 #include <unistd.h>
 
 #include <cstring>
+#include <memory>
 
 #include "./httpserver.hpp"
 #include "./littletest.hpp"

--- a/test/integ/file_upload.cpp
+++ b/test/integ/file_upload.cpp
@@ -23,6 +23,7 @@
 #include <cassert>
 #include <cstddef>
 #include <fstream>
+#include <memory>
 #include <map>
 #include <random>
 #include <sstream>
@@ -219,8 +220,7 @@ class print_file_upload_resource : public http_resource {
             }
          }
          files = req.get_files();
-         shared_ptr<string_response> hresp(new string_response("OK", 201, "text/plain"));
-         return hresp;
+         return std::make_shared<string_response>("OK", 201, "text/plain");
      }
 
      shared_ptr<http_response> render_PUT(const http_request& req) {
@@ -233,8 +233,7 @@ class print_file_upload_resource : public http_resource {
             }
          }
          files = req.get_files();
-         shared_ptr<string_response> hresp(new string_response("OK", 200, "text/plain"));
-         return hresp;
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 
      const std::map<string, std::vector<string>, httpserver::http::arg_comparator> get_args() const {
@@ -277,9 +276,8 @@ LT_END_AUTO_TEST(check_files)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk)
     string upload_directory = ".";
-    webserver* ws;
 
-    ws = new webserver(create_webserver(PORT)
+    auto ws = std::make_unique<webserver>(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_AND_DISK)
                        .file_upload_dir(upload_directory)
@@ -295,7 +293,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk)
     LT_ASSERT_EQ(res.second, 201);
 
     ws->stop();
-    delete ws;
 
     string actual_content = resource.get_content();
     LT_CHECK_EQ(actual_content.find(FILENAME_IN_GET_CONTENT) != string::npos, true);
@@ -327,9 +324,8 @@ LT_END_AUTO_TEST(file_upload_memory_and_disk)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_via_put)
     string upload_directory = ".";
-    webserver* ws;
 
-    ws = new webserver(create_webserver(PORT)
+    auto ws = std::make_unique<webserver>(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_AND_DISK)
                        .file_upload_dir(upload_directory)
@@ -355,14 +351,12 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_via_put)
     LT_CHECK_EQ(files.size(), 0);
 
     ws->stop();
-    delete ws;
 LT_END_AUTO_TEST(file_upload_memory_and_disk_via_put)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_additional_params)
     string upload_directory = ".";
-    webserver* ws;
 
-    ws = new webserver(create_webserver(PORT)
+    auto ws = std::make_unique<webserver>(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_AND_DISK)
                        .file_upload_dir(upload_directory)
@@ -378,7 +372,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_additional_par
     LT_ASSERT_EQ(res.second, 201);
 
     ws->stop();
-    delete ws;
 
     string actual_content = resource.get_content();
     LT_CHECK_EQ(actual_content.find(FILENAME_IN_GET_CONTENT) != string::npos, true);
@@ -415,9 +408,8 @@ LT_END_AUTO_TEST(file_upload_memory_and_disk_additional_params)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_two_files)
     string upload_directory = ".";
-    webserver* ws;
 
-    ws = new webserver(create_webserver(PORT)
+    auto ws = std::make_unique<webserver>(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_AND_DISK)
                        .file_upload_dir(upload_directory)
@@ -433,7 +425,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_and_disk_two_files)
     LT_ASSERT_EQ(res.second, 201);
 
     ws->stop();
-    delete ws;
 
     string actual_content = resource.get_content();
     LT_CHECK_EQ(actual_content.find(FILENAME_IN_GET_CONTENT) != string::npos, true);
@@ -485,9 +476,8 @@ LT_END_AUTO_TEST(file_upload_memory_and_disk_two_files)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_disk_only)
     string upload_directory = ".";
-    webserver* ws;
 
-    ws = new webserver(create_webserver(PORT)
+    auto ws = std::make_unique<webserver>(create_webserver(PORT)
                        .no_put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_DISK_ONLY)
                        .file_upload_dir(upload_directory)
@@ -503,7 +493,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_disk_only)
     LT_ASSERT_EQ(res.second, 201);
 
     ws->stop();
-    delete ws;
 
     string actual_content = resource.get_content();
     LT_CHECK_EQ(actual_content.size(), 0);
@@ -530,9 +519,7 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_disk_only)
 LT_END_AUTO_TEST(file_upload_disk_only)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_incl_content)
-    webserver* ws;
-
-    ws = new webserver(create_webserver(PORT)
+    auto ws = std::make_unique<webserver>(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_ONLY));
     ws->start(false);
@@ -559,13 +546,10 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_incl_content)
     LT_CHECK_EQ(resource.get_files().size(), 0);
 
     ws->stop();
-    delete ws;
 LT_END_AUTO_TEST(file_upload_memory_only_incl_content)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_large_content)
-    webserver* ws;
-
-    ws = new webserver(create_webserver(PORT)
+    auto ws = std::make_unique<webserver>(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_ONLY));
     ws->start(false);
@@ -599,13 +583,10 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_large_content)
     LT_CHECK_EQ(resource.get_files().size(), 0);
 
     ws->stop();
-    delete ws;
 LT_END_AUTO_TEST(file_upload_large_content)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_large_content_with_args)
-    webserver* ws;
-
-    ws = new webserver(create_webserver(PORT)
+    auto ws = std::make_unique<webserver>(create_webserver(PORT)
                        .put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_ONLY));
     ws->start(false);
@@ -645,13 +626,10 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_large_content_with_args)
     LT_CHECK_EQ(resource.get_files().size(), 0);
 
     ws->stop();
-    delete ws;
 LT_END_AUTO_TEST(file_upload_large_content_with_args)
 
 LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_excl_content)
-    webserver* ws;
-
-    ws = new webserver(create_webserver(PORT)
+    auto ws = std::make_unique<webserver>(create_webserver(PORT)
                        .no_put_processed_data_to_content()
                        .file_upload_target(httpserver::FILE_UPLOAD_MEMORY_ONLY));
     ws->start(false);
@@ -677,7 +655,6 @@ LT_BEGIN_AUTO_TEST(file_upload_suite, file_upload_memory_only_excl_content)
     LT_CHECK_EQ(files.size(), 0);
 
     ws->stop();
-    delete ws;
 LT_END_AUTO_TEST(file_upload_memory_only_excl_content)
 
 LT_BEGIN_AUTO_TEST_ENV()

--- a/test/integ/nodelay.cpp
+++ b/test/integ/nodelay.cpp
@@ -20,6 +20,7 @@
 
 #include <curl/curl.h>
 #include <map>
+#include <memory>
 #include <string>
 
 #include "./httpserver.hpp"
@@ -48,21 +49,20 @@ using httpserver::create_webserver;
 class ok_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 };
 
 LT_BEGIN_SUITE(threaded_suite)
-    webserver* ws;
+    std::unique_ptr<webserver> ws;
 
     void set_up() {
-        ws = new webserver(create_webserver(PORT).tcp_nodelay());
+        ws = std::make_unique<webserver>(create_webserver(PORT));
         ws->start(false);
     }
 
     void tear_down() {
         ws->stop();
-        delete ws;
     }
 LT_END_SUITE(threaded_suite)
 

--- a/test/integ/threaded.cpp
+++ b/test/integ/threaded.cpp
@@ -24,6 +24,7 @@
 
 #include <curl/curl.h>
 #include <map>
+#include <memory>
 #include <string>
 
 #include "./httpserver.hpp"
@@ -51,19 +52,19 @@ using httpserver::create_webserver;
 class ok_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK", 200, "text/plain"));
+         return std::make_shared<string_response>("OK", 200, "text/plain");
      }
 };
 
 LT_BEGIN_SUITE(threaded_suite)
 
 #ifndef _WINDOWS
-    webserver* ws;
+    std::unique_ptr<webserver> ws;
 #endif
 
     void set_up() {
 #ifndef _WINDOWS
-        ws = new webserver(create_webserver(PORT).start_method(httpserver::http::http_utils::INTERNAL_SELECT).max_threads(5));
+        ws = std::make_unique<webserver>(create_webserver(PORT).start_method(httpserver::http::http_utils::INTERNAL_SELECT).max_threads(5));
         ws->start(false);
 #endif
     }
@@ -71,7 +72,6 @@ LT_BEGIN_SUITE(threaded_suite)
     void tear_down() {
 #ifndef _WINDOWS
         ws->stop();
-        delete ws;
 #endif
     }
 LT_END_SUITE(threaded_suite)

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -33,6 +33,7 @@
 #include <curl/curl.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <memory>
 
 #include "./httpserver.hpp"
 #include "./littletest.hpp"
@@ -63,16 +64,16 @@ size_t writefunc(void *ptr, size_t size, size_t nmemb, std::string *s) {
 class ok_resource : public httpserver::http_resource {
  public:
      shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request&) {
-         return shared_ptr<httpserver::string_response>(new httpserver::string_response("OK", 200, "text/plain"));
+         return std::make_shared<httpserver::string_response>("OK", 200, "text/plain");
      }
 };
 
 shared_ptr<httpserver::http_response> not_found_custom(const httpserver::http_request&) {
-    return shared_ptr<httpserver::string_response>(new httpserver::string_response("Not found custom", 404, "text/plain"));
+    return std::make_shared<httpserver::string_response>("Not found custom", 404, "text/plain");
 }
 
 shared_ptr<httpserver::http_response> not_allowed_custom(const httpserver::http_request&) {
-    return shared_ptr<httpserver::string_response>(new httpserver::string_response("Not allowed custom", 405, "text/plain"));
+    return std::make_shared<httpserver::string_response>("Not allowed custom", 405, "text/plain");
 }
 
 LT_BEGIN_SUITE(ws_start_stop_suite)

--- a/test/unit/http_resource_test.cpp
+++ b/test/unit/http_resource_test.cpp
@@ -41,7 +41,7 @@ using httpserver::string_response;
 class simple_resource : public http_resource {
  public:
      shared_ptr<http_response> render_GET(const http_request&) {
-         return shared_ptr<string_response>(new string_response("OK"));
+         return std::make_shared<string_response>("OK");
      }
 };
 

--- a/test/unit/http_utils_test.cpp
+++ b/test/unit/http_utils_test.cpp
@@ -56,59 +56,36 @@ LT_BEGIN_SUITE(http_utils_suite)
 LT_END_SUITE(http_utils_suite)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, unescape)
-    int with_plus_buff_len = 6;
-    char* with_plus = new char[with_plus_buff_len];
-    snprintf(with_plus, with_plus_buff_len, "%s", "A%20B");
-    std::string string_with_plus = with_plus;
+    std::string string_with_plus = "A%20B";
     int expected_size = httpserver::http::http_unescape(&string_with_plus);
 
-    int expected_buff_len = 4;
-    char* expected = new char[expected_buff_len];
-    snprintf(expected, expected_buff_len, "%s", "A B");
+    std::string expected = "A B";
 
     std::cout << "|||||" << string_with_plus << "||||" << std::endl;
     std::cout << expected << std::endl;
 
-    LT_CHECK_EQ(string_with_plus, string(expected));
+    LT_CHECK_EQ(string_with_plus, expected);
     LT_CHECK_EQ(expected_size, 3);
-
-    delete[] with_plus;
-    delete[] expected;
 LT_END_AUTO_TEST(unescape)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, unescape_plus)
-    int with_plus_buff_len = 4;
-    char* with_plus = new char[with_plus_buff_len];
-    snprintf(with_plus, with_plus_buff_len, "%s", "A+B");
-    std::string string_with_plus = with_plus;
+    std::string string_with_plus = "A+B";
     int expected_size = httpserver::http::http_unescape(&string_with_plus);
 
-    int expected_buff_len = 4;
-    char* expected = new char[expected_buff_len];
-    snprintf(expected, expected_buff_len, "%s", "A B");
+    std::string expected = "A B";
 
-    LT_CHECK_EQ(string_with_plus, string(expected));
+    LT_CHECK_EQ(string_with_plus, expected);
     LT_CHECK_EQ(expected_size, 3);
-
-    delete[] with_plus;
-    delete[] expected;
 LT_END_AUTO_TEST(unescape_plus)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, unescape_partial_marker)
-    int size = 6;
-    char* with_marker = new char[size];
-    snprintf(with_marker, size, "%s", "A+B%0");
-    std::string string_with_marker = with_marker;
+    std::string string_with_marker = "A+B%0";
     int expected_size = httpserver::http::http_unescape(&string_with_marker);
 
-    char* expected = new char[size];
-    snprintf(expected, size, "%s", "A B%0");
+    std::string expected = "A B%0";
 
-    LT_CHECK_EQ(string_with_marker, string(expected));
+    LT_CHECK_EQ(string_with_marker, expected);
     LT_CHECK_EQ(expected_size, 5);
-
-    delete[] with_marker;
-    delete[] expected;
 LT_END_AUTO_TEST(unescape_partial_marker)
 
 LT_BEGIN_AUTO_TEST(http_utils_suite, tokenize_url)


### PR DESCRIPTION
Modern C++ *almost* never needs raw `new` or `delete` and the alternatives are general less error prone.