### PR TITLE
Fix bug preventing GET params from being read on parametrized URLs.

### DIFF
--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -105,13 +105,15 @@ const http::header_view_map http_request::get_cookies() const {
 }
 
 void http_request::populate_args() const {
-    if (!cache->unescaped_args.empty()) {
+    if (cache->args_populated) {
         return;
     }
     arguments_accumulator aa;
     aa.unescaper = unescaper;
     aa.arguments = &cache->unescaped_args;
     MHD_get_connection_values(underlying_connection, MHD_GET_ARGUMENT_KIND, &build_request_args, reinterpret_cast<void*>(&aa));
+
+    cache->args_populated = true;
 }
 
 http_arg_value http_request::get_arg(std::string_view key) const {

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -410,6 +410,8 @@ class http_request {
         std::string requestor_ip;
         std::string digested_user;
         std::map<std::string, std::vector<std::string>, http::arg_comparator> unescaped_args;
+
+        bool args_populated = false;
      };
      std::unique_ptr<http_request_data_cache> cache = std::make_unique<http_request_data_cache>();
      // Populate the data cache unescaped_args

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -948,6 +948,24 @@ LT_BEGIN_AUTO_TEST(basic_suite, regex_matching_arg)
     curl_easy_cleanup(curl);
 LT_END_AUTO_TEST(regex_matching_arg)
 
+LT_BEGIN_AUTO_TEST(basic_suite, regex_matching_arg_with_url_pars)
+    args_resource resource;
+    LT_ASSERT_EQ(true, ws->register_resource("this/captures/{arg}/passed/in/input", &resource));
+    curl_global_init(CURL_GLOBAL_ALL);
+
+    string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/this/captures/whatever/passed/in/input?arg2=second_argument");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(s, "whateversecond_argument");
+    curl_easy_cleanup(curl);
+LT_END_AUTO_TEST(regex_matching_arg_with_url_pars)
+
 LT_BEGIN_AUTO_TEST(basic_suite, regex_matching_arg_custom)
     args_resource resource;
     LT_ASSERT_EQ(true, ws->register_resource("this/captures/numeric/{arg|([0-9]+)}/passed/in/input", &resource));


### PR DESCRIPTION
### Identify the Bug

It is not possible to get querystring arguments when using parameterized paths.

See: https://github.com/etr/libhttpserver/issues/325

### Description of the Change

The bug was due to the populate_args method checking whether the cache was empty before executing. By doing so, it was ignoring that in case of parametrized URLs, the webserver class was loading the params as arguments. The new system uses a boolean specifically managed by the populate_args method.

### Alternate Designs

N/D

### Possible Drawbacks

None

### Verification Process

Integration tests

### Release Notes

Fixed bug preventing GET params from being read on parametrized URLs.