### PR TITLE
Fix post processor breaking large fields in multiple parts.

### DIFF
--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -116,6 +116,21 @@ void http_request::populate_args() const {
     cache->args_populated = true;
 }
 
+
+void http_request::grow_last_arg(const std::string& key, const std::string& value) {
+    auto it = cache->unescaped_args.find(key);
+
+    if (it != cache->unescaped_args.end()) {
+        if (!it->second.empty()) {
+            it->second.back() += value;
+        } else {
+            it->second.push_back(value);
+        }
+    } else {
+        cache->unescaped_args[key] = {value};
+    }
+}
+
 http_arg_value http_request::get_arg(std::string_view key) const {
     populate_args();
 

--- a/src/httpserver/http_request.hpp
+++ b/src/httpserver/http_request.hpp
@@ -335,6 +335,9 @@ class http_request {
      void set_arg_flat(const std::string& key, const std::string& value) {
          cache->unescaped_args[key] = { (value.substr(0, content_size_limit)) };
      }
+
+     void grow_last_arg(const std::string& key, const std::string& value);
+
      /**
       * Method used to set the content of the request
       * @param content The content to set.

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -467,12 +467,16 @@ MHD_Result webserver::post_iterator(void *cls, enum MHD_ValueKind kind,
         const char *transfer_encoding, const char *data, uint64_t off, size_t size) {
     // Parameter needed to respect MHD interface, but not needed here.
     std::ignore = kind;
-    std::ignore = off;
 
     struct details::modded_request* mr = (struct details::modded_request*) cls;
 
     if (!filename) {
         // There is no actual file, just set the arg key/value and return.
+        if (off > 0) {
+            mr->dhr->grow_last_arg(key, std::string(data, size));
+            return MHD_YES;
+        }
+
         mr->dhr->set_arg(key, std::string(data, size));
         return MHD_YES;
     }

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -854,26 +854,25 @@ LT_BEGIN_AUTO_TEST(basic_suite, postprocessor_large_field_last_field)
     CURLcode res;
 
     const int size = 20000;
-    const char* value = "A";
+    const char value = 'A';
     const char* prefix = "arg1=BB&arg1=";
-    const char* suffix = "";
 
     // Calculate the total length of the string
-    int totalLength = std::strlen(prefix) + std::strlen(suffix) + size * std::strlen(value);
+    int totalLength = std::strlen(prefix) + size;
 
     // Allocate memory for the char array
-    char* cString = new char[totalLength + 1]; // +1 for the null terminator
+    char* cString = new char[totalLength + 1];  // +1 for the null terminator
 
     // Copy the prefix
-    std::strcpy(cString, prefix);
+    int offset = std::snprintf(cString, totalLength + 1, "%s", prefix);
 
     // Append 20,000 times the character 'A' to the string
     for (int i = 0; i < size; ++i) {
-        std::strcat(cString, value);
+        cString[offset++] = value;
     }
 
     // Append the suffix
-    std::strcat(cString, suffix);
+    cString[offset] = '\0';
 
     curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, cString);
@@ -896,30 +895,30 @@ LT_BEGIN_AUTO_TEST(basic_suite, postprocessor_large_field_first_field)
     CURLcode res;
 
     const int size = 20000;
-    const char* value = "A";
+    const char value = 'A';
     const char* prefix = "arg1=";
     const char* middle = "&arg1=";
     const char* suffix = "BB";
 
     // Calculate the total length of the string
-    int totalLength = std::strlen(prefix) + size * std::strlen(value) + std::strlen(middle) + std::strlen(suffix);
+    int totalLength = std::strlen(prefix) + size + std::strlen(middle) + std::strlen(suffix);
 
     // Allocate memory for the char array
-    char* cString = new char[totalLength + 1]; // +1 for the null terminator
+    char* cString = new char[totalLength + 1];  // +1 for the null terminator
 
     // Copy the prefix
-    std::strcpy(cString, prefix);
+    int offset = std::snprintf(cString, totalLength + 1, "%s", prefix);
 
     // Append 20,000 times the character 'A' to the string
     for (int i = 0; i < size; ++i) {
-        std::strcat(cString, value);
+        cString[offset++] = value;
     }
 
     // Append the middle part
-    std::strcat(cString, middle);
+    offset += std::snprintf(cString + offset, totalLength + 1 - offset, "%s", middle);
 
     // Append the suffix
-    std::strcat(cString, suffix);
+    std::snprintf(cString + offset, totalLength + 1 - offset, "%s", suffix);
 
     curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/base");
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, cString);

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <curl/curl.h>
+#include <cstring>
 #include <map>
 #include <memory>
 #include <numeric>


### PR DESCRIPTION
### Identify the Bug

The post processor was breaking up large post fields into multiple values as if provided separately.

### Description of the Change

Now the post processor checks for the offset value. If there is an offset, the value must be a part of a large post field and not an independent repeated value. In this case, we just append to the latest value for the specified argument.

### Alternate Designs

None

### Possible Drawbacks

None

### Verification Process

Added new integration tests.

### Release Notes

Fixed the post processor that was breaking up large post fields into multiple values as if provided separately.