### PR TITLE
Update verify-build.yml

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -339,25 +339,25 @@ jobs:
         sudo make install ;
       if: ${{ matrix.build-type == 'iwyu' && matrix.os-type == 'ubuntu' }}
 
-    - name: CURL from cache (for testing)
+    - name: CURL from cache (for testing on mac)
       id: cache-CURL
       uses: actions/cache@v2
       with:
-        path: curl-7.75.0
+        path: curl-8.8.0
         key: ${{ matrix.os }}-CURL-pre-built
       if: ${{ matrix.os == 'macos-latest' }}
     
-    - name: Build CURL (for testing)
+    - name: Build CURL (for testing on mac)
       run: |
-        curl https://libhttpserver.s3.amazonaws.com/travis_stuff/curl-7.75.0.tar.gz -o curl-7.75.0.tar.gz ;
-        tar -xzf curl-7.75.0.tar.gz ;
-        cd curl-7.75.0 ;
+        curl https://libhttpserver.s3.amazonaws.com/travis_stuff/curl-8.8.0.tar -o curl-8.8.0.tar ;
+        tar -xzf curl-8.8.0.tar ;
+        cd curl-8.8.0 ;
         if [ "$matrix.os-type" = "ubuntu" ]; then ./configure ; else ./configure --with-darwinssl ; fi
         make ;
       if: ${{ matrix.os == 'macos-latest' && steps.cache-CURL.outputs.cache-hit != 'true' }}
       
     - name: Install CURL (for testing on mac only) 
-      run: cd curl-7.75.0 ; sudo make install ;
+      run: cd curl-8.8.0 ; sudo make install ;
       if: ${{ matrix.os == 'macos-latest' }}
  
     - name: Install CURL (for testing on linux)


### PR DESCRIPTION
### Identify the Bug

Curl building for testing is currently failing on macOS latest on GitHub actions.

### Description of the Change

Upgrade curl to the latest version that should be compatible with macOS latest.

### Alternate Designs

N/D

### Possible Drawbacks

N/D

### Verification Process

Unit/integ test

### Release Notes

N/D. Build system fix.