### PR TITLE
Fix have_gnutls test in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,7 +245,7 @@ AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$enable_examples" = "xyes"])
 AM_CONDITIONAL([COND_GCOV],[test x"$cond_gcov" = x"yes"])
 AC_SUBST(COND_GCOV)
 
-if test x"have_gnutls" = x"yes"; then
+if test x"$have_gnutls" = x"yes"; then
     AM_CXXFLAGS="$AM_CXXFLAGS -DHAVE_GNUTLS"
     AM_CFLAGS="$AM_CXXFLAGS -DHAVE_GNUTLS"
 fi


### PR DESCRIPTION
Closes #340.

### Description of the Change

Fixes the test for `have_gnutls` in `configure.ac` ; even though the GnuTLS is  correctly detected, the `-DHAVE_GNUTLS` is not added to `CFLAGS` as the check always considers the GnuTLS to not exist.

### Release Notes

- Fix GnuTLS detection in configure step.