### PR TITLE
Fix kernel version check for TCP_FASTOPEN support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,14 +149,12 @@ AC_ARG_ENABLE([fastopen],
 AC_MSG_RESULT([$fastopen])
 
 is_fastopen_supported=no;
-if test x"$fastopen" = x"yes"; then
-    if test x"$is_windows" = x"no"; then
-        if test `uname -r |cut -d. -f1` -ge 3; then
-            if test `uname -r |cut -d. -f2` -ge 7; then
-                CXXFLAGS="-DUSE_FASTOPEN $CXXFLAGS";
-                is_fastopen_supported=yes;
-            fi
-        fi
+if test x"$fastopen" = x"yes" && test x"$is_windows" = x"no"; then
+    major=`uname -r | cut -d. -f1`
+    minor=`uname -r | cut -d. -f2`
+    if test "$major" -ge 4 || { test "$major" -eq 3 && test "$minor" -ge 7; }; then
+            CXXFLAGS="-DUSE_FASTOPEN $CXXFLAGS";
+            is_fastopen_supported=yes;
     fi
 fi
 


### PR DESCRIPTION
### Identify the Bug

https://github.com/etr/libhttpserver/issues/346

### Description of the Change

Corrected the logic used to determine whether TCP_FASTOPEN should be enabled based on the Linux kernel version.

The original version incorrectly evaluated some kernel versions and  it only allowed TCP_FASTOPEN on version Kernel 3.7+, but failed to correctly handle minor version.

For example, kernel versions 6.1 and 6.6 were incorrectly excluded, even though they support TCP_FASTOPEN because its minor version is lower than "7".

### Alternate Designs

None.

### Possible Drawbacks

None.

### Verification Process

I search for related commits to TCP_FASTOPEN and I can find only the first commit introducing the value check 10 years ago: https://github.com/etr/libhttpserver/commit/8786b2f4c910a69cec0095e4a8bc732cce919d50
The first commit suggests Kernel 3.6 to support TCP_FASTOPEN, but a newer commit change it to 3.7. I use git blame to find it: https://github.com/etr/libhttpserver/commit/8786b2f4c910a69cec0095e4a8bc732cce919d50

### Release Notes

- Fixed kernel version check for TCP_FASTOPEN support
