### PR TITLE
Fix segfault when passing nullptr to register_resource (issue #265)

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -191,6 +191,10 @@ void webserver::request_completed(void *cls, struct MHD_Connection *connection, 
 }
 
 bool webserver::register_resource(const std::string& resource, http_resource* hrm, bool family) {
+    if (hrm == nullptr) {
+        throw std::invalid_argument("The http_resource pointer cannot be null");
+    }
+
     if (single_resource && ((resource != "" && resource != "/") || !family)) {
         throw std::invalid_argument("The resource should be '' or '/' and be marked as family when using a single_resource server");
     }

--- a/test/integ/ws_start_stop.cpp
+++ b/test/integ/ws_start_stop.cpp
@@ -372,6 +372,11 @@ LT_BEGIN_AUTO_TEST(ws_start_stop_suite, single_resource_not_default_resource)
     ws.stop();
 LT_END_AUTO_TEST(single_resource_not_default_resource)
 
+LT_BEGIN_AUTO_TEST(ws_start_stop_suite, register_resource_nullptr_throws)
+    httpserver::webserver ws = httpserver::create_webserver(PORT);
+    LT_CHECK_THROW(ws.register_resource("/test", nullptr));
+LT_END_AUTO_TEST(register_resource_nullptr_throws)
+
 LT_BEGIN_AUTO_TEST(ws_start_stop_suite, thread_per_connection_fails_with_max_threads)
     { // NOLINT (internal scope opening - not method start)
     httpserver::webserver ws = httpserver::create_webserver(PORT)


### PR DESCRIPTION
## Summary
- Add null pointer validation to `webserver::register_resource()` that throws `std::invalid_argument` when a null `http_resource*` is passed
- Previously, passing `nullptr` would cause a segfault at runtime when the resource was accessed

Fixes #265

## Test plan
- Added test case `register_resource_nullptr_throws` in `test/integ/ws_start_stop.cpp`
- All existing tests pass (`make check`)