### PR TITLE
Fix regex URL exact match bug (issue #308)

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -204,7 +204,7 @@ bool webserver::register_resource(const std::string& resource, http_resource* hr
     std::unique_lock registered_resources_lock(registered_resources_mutex);
     pair<map<details::http_endpoint, http_resource*>::iterator, bool> result = registered_resources.insert(map<details::http_endpoint, http_resource*>::value_type(idx, hrm));
 
-    if (!family && result.second) {
+    if (!family && result.second && idx.get_url_pars().empty()) {
         registered_resources_str.insert(pair<string, http_resource*>(idx.get_url_complete(), result.first->second));
     }
 

--- a/test/integ/basic.cpp
+++ b/test/integ/basic.cpp
@@ -1595,11 +1595,7 @@ LT_BEGIN_AUTO_TEST(basic_suite, regex_url_exact_match)
 
     int64_t http_code = 0;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE , &http_code);
-#if 0    //  https://github.com/etr/libhttpserver/issues/308
     LT_ASSERT_EQ(http_code, 404);
-#else
-    LT_ASSERT_EQ(http_code, 200);
-#endif
     curl_easy_cleanup(curl);
     }
 LT_END_AUTO_TEST(regex_url_exact_match)


### PR DESCRIPTION
## Summary
- Fix bug where URLs exactly matching a registered regex pattern string incorrectly dispatch to that resource instead of returning 404
- Only add URLs without regex patterns to the fast string lookup map by checking `idx.get_url_pars().empty()` before insertion
- Enable the previously disabled test case in `basic.cpp`

Fixes #308

## Test plan
- [x] `regex_url_exact_match` test passes with expected 404 response
- [x] All 12 tests pass (`make check`)