### PR TITLE
Add centralized authentication handler (issue #102)

### DIFF
--- a/examples/centralized_authentication.cpp
+++ b/examples/centralized_authentication.cpp
@@ -1,0 +1,88 @@
+/*
+     This file is part of libhttpserver
+     Copyright (C) 2011, 2012, 2013, 2014, 2015 Sebastiano Merlino
+
+     This library is free software; you can redistribute it and/or
+     modify it under the terms of the GNU Lesser General Public
+     License as published by the Free Software Foundation; either
+     version 2.1 of the License, or (at your option) any later version.
+
+     This library is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+     Lesser General Public License for more details.
+
+     You should have received a copy of the GNU Lesser General Public
+     License along with this library; if not, write to the Free Software
+     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+     USA
+*/
+
+#include <memory>
+#include <string>
+
+#include <httpserver.hpp>
+
+using httpserver::http_request;
+using httpserver::http_response;
+using httpserver::http_resource;
+using httpserver::webserver;
+using httpserver::create_webserver;
+using httpserver::string_response;
+using httpserver::basic_auth_fail_response;
+
+// Simple resource that doesn't need to handle auth itself
+class hello_resource : public http_resource {
+ public:
+    std::shared_ptr<http_response> render_GET(const http_request&) {
+        return std::make_shared<string_response>("Hello, authenticated user!", 200, "text/plain");
+    }
+};
+
+class health_resource : public http_resource {
+ public:
+    std::shared_ptr<http_response> render_GET(const http_request&) {
+        return std::make_shared<string_response>("OK", 200, "text/plain");
+    }
+};
+
+// Centralized authentication handler
+// Returns nullptr to allow the request, or an http_response to reject it
+std::shared_ptr<http_response> auth_handler(const http_request& req) {
+    if (req.get_user() != "admin" || req.get_pass() != "secret") {
+        return std::make_shared<basic_auth_fail_response>("Unauthorized", "MyRealm");
+    }
+    return nullptr;  // Allow request
+}
+
+int main() {
+    // Create webserver with centralized authentication
+    // - auth_handler: called before every resource's render method
+    // - auth_skip_paths: paths that bypass authentication
+    webserver ws = create_webserver(8080)
+        .auth_handler(auth_handler)
+        .auth_skip_paths({"/health", "/public/*"});
+
+    hello_resource hello;
+    health_resource health;
+
+    ws.register_resource("/api", &hello);
+    ws.register_resource("/health", &health);
+
+    ws.start(true);
+
+    return 0;
+}
+
+// Usage:
+//   # Start the server
+//   ./centralized_authentication
+//
+//   # Without auth - should get 401 Unauthorized
+//   curl -v http://localhost:8080/api
+//
+//   # With valid auth - should get 200 OK
+//   curl -u admin:secret http://localhost:8080/api
+//
+//   # Health endpoint (skip path) - works without auth
+//   curl http://localhost:8080/health

--- a/src/httpserver/create_webserver.hpp
+++ b/src/httpserver/create_webserver.hpp
@@ -31,6 +31,7 @@
 #include <limits>
 #include <string>
 #include <variant>
+#include <vector>
 
 #include "httpserver/http_response.hpp"
 #include "httpserver/http_utils.hpp"
@@ -52,6 +53,7 @@ typedef std::function<std::string(const std::string&)> psk_cred_handler_callback
 namespace http { class file_info; }
 
 typedef std::function<bool(const std::string&, const std::string&, const http::file_info&)> file_cleanup_callback_ptr;
+typedef std::function<std::shared_ptr<http_response>(const http_request&)> auth_handler_ptr;
 
 class create_webserver {
  public:
@@ -376,6 +378,16 @@ class create_webserver {
          return *this;
      }
 
+     create_webserver& auth_handler(auth_handler_ptr handler) {
+         _auth_handler = handler;
+         return *this;
+     }
+
+     create_webserver& auth_skip_paths(const std::vector<std::string>& paths) {
+         _auth_skip_paths = paths;
+         return *this;
+     }
+
  private:
      uint16_t _port = DEFAULT_WS_PORT;
      http::http_utils::start_method_T _start_method = http::http_utils::INTERNAL_SELECT;
@@ -423,6 +435,8 @@ class create_webserver {
      render_ptr _method_not_allowed_resource = nullptr;
      render_ptr _internal_error_resource = nullptr;
      file_cleanup_callback_ptr _file_cleanup_callback = nullptr;
+     auth_handler_ptr _auth_handler = nullptr;
+     std::vector<std::string> _auth_skip_paths;
 
      friend class webserver;
 };

--- a/src/httpserver/webserver.hpp
+++ b/src/httpserver/webserver.hpp
@@ -45,6 +45,7 @@
 #include <set>
 #include <shared_mutex>
 #include <string>
+#include <vector>
 
 #ifdef HAVE_GNUTLS
 #include <gnutls/gnutls.h>
@@ -182,6 +183,8 @@ class webserver {
      const render_ptr method_not_allowed_resource;
      const render_ptr internal_error_resource;
      const file_cleanup_callback_ptr file_cleanup_callback;
+     const auth_handler_ptr auth_handler;
+     const std::vector<std::string> auth_skip_paths;
      std::shared_mutex registered_resources_mutex;
      std::map<details::http_endpoint, http_resource*> registered_resources;
      std::map<std::string, http_resource*> registered_resources_str;
@@ -197,6 +200,7 @@ class webserver {
      std::shared_ptr<http_response> method_not_allowed_page(details::modded_request* mr) const;
      std::shared_ptr<http_response> internal_error_page(details::modded_request* mr, bool force_our = false) const;
      std::shared_ptr<http_response> not_found_page(details::modded_request* mr) const;
+     bool should_skip_auth(const std::string& path) const;
 
      static void request_completed(void *cls,
              struct MHD_Connection *connection, void **con_cls,

--- a/test/integ/authentication.cpp
+++ b/test/integ/authentication.cpp
@@ -239,6 +239,418 @@ LT_END_AUTO_TEST(digest_auth_wrong_pass)
 
 #endif
 
+// Simple resource for centralized auth tests
+class simple_resource : public http_resource {
+ public:
+     shared_ptr<http_response> render_GET(const http_request&) {
+         return std::make_shared<string_response>("SUCCESS", 200, "text/plain");
+     }
+};
+
+// Centralized authentication handler
+std::shared_ptr<http_response> centralized_auth_handler(const http_request& req) {
+    if (req.get_user() != "admin" || req.get_pass() != "secret") {
+        return std::make_shared<basic_auth_fail_response>("Unauthorized", "testrealm");
+    }
+    return nullptr;  // Allow request
+}
+
+LT_BEGIN_AUTO_TEST(authentication_suite, centralized_auth_fail)
+    webserver ws = create_webserver(PORT)
+        .auth_handler(centralized_auth_handler);
+
+    simple_resource sr;
+    LT_ASSERT_EQ(true, ws.register_resource("protected", &sr));
+    ws.start(false);
+
+    curl_global_init(CURL_GLOBAL_ALL);
+    std::string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    long http_code = 0;  // NOLINT(runtime/int)
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/protected");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 401);
+    LT_CHECK_EQ(s, "Unauthorized");
+    curl_easy_cleanup(curl);
+
+    ws.stop();
+LT_END_AUTO_TEST(centralized_auth_fail)
+
+LT_BEGIN_AUTO_TEST(authentication_suite, centralized_auth_success)
+    webserver ws = create_webserver(PORT)
+        .auth_handler(centralized_auth_handler);
+
+    simple_resource sr;
+    LT_ASSERT_EQ(true, ws.register_resource("protected", &sr));
+    ws.start(false);
+
+    curl_global_init(CURL_GLOBAL_ALL);
+    std::string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    long http_code = 0;  // NOLINT(runtime/int)
+    curl_easy_setopt(curl, CURLOPT_USERNAME, "admin");
+    curl_easy_setopt(curl, CURLOPT_PASSWORD, "secret");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/protected");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 200);
+    LT_CHECK_EQ(s, "SUCCESS");
+    curl_easy_cleanup(curl);
+
+    ws.stop();
+LT_END_AUTO_TEST(centralized_auth_success)
+
+LT_BEGIN_AUTO_TEST(authentication_suite, auth_skip_paths)
+    webserver ws = create_webserver(PORT)
+        .auth_handler(centralized_auth_handler)
+        .auth_skip_paths({"/health", "/public/*"});
+
+    simple_resource sr;
+    LT_ASSERT_EQ(true, ws.register_resource("health", &sr));
+    LT_ASSERT_EQ(true, ws.register_resource("public/info", &sr));
+    LT_ASSERT_EQ(true, ws.register_resource("protected", &sr));
+    ws.start(false);
+
+    curl_global_init(CURL_GLOBAL_ALL);
+    CURL *curl;
+    CURLcode res;
+    long http_code = 0;  // NOLINT(runtime/int)
+    std::string s;
+
+    // Test /health (exact match skip path) - should succeed without auth
+    curl = curl_easy_init();
+    s = "";
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/health");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 200);
+    LT_CHECK_EQ(s, "SUCCESS");
+    curl_easy_cleanup(curl);
+
+    // Test /public/info (wildcard skip path) - should succeed without auth
+    curl = curl_easy_init();
+    s = "";
+    http_code = 0;
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/public/info");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 200);
+    LT_CHECK_EQ(s, "SUCCESS");
+    curl_easy_cleanup(curl);
+
+    // Test /protected (not in skip paths) - should fail without auth
+    curl = curl_easy_init();
+    s = "";
+    http_code = 0;
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/protected");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 401);
+    curl_easy_cleanup(curl);
+
+    ws.stop();
+LT_END_AUTO_TEST(auth_skip_paths)
+
+// Test that wildcard doesn't match partial prefix
+// /publicinfo should NOT match /public/* (wildcard requires the slash)
+LT_BEGIN_AUTO_TEST(authentication_suite, auth_skip_paths_no_partial_match)
+    webserver ws = create_webserver(PORT)
+        .auth_handler(centralized_auth_handler)
+        .auth_skip_paths({"/public/*"});
+
+    simple_resource sr;
+    LT_ASSERT_EQ(true, ws.register_resource("publicinfo", &sr));
+    ws.start(false);
+
+    curl_global_init(CURL_GLOBAL_ALL);
+    std::string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    long http_code = 0;  // NOLINT(runtime/int)
+
+    // /publicinfo should NOT be skipped (doesn't match /public/*)
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/publicinfo");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 401);  // Should require auth
+    curl_easy_cleanup(curl);
+
+    ws.stop();
+LT_END_AUTO_TEST(auth_skip_paths_no_partial_match)
+
+// Test deeply nested wildcard paths
+LT_BEGIN_AUTO_TEST(authentication_suite, auth_skip_paths_deep_nested)
+    webserver ws = create_webserver(PORT)
+        .auth_handler(centralized_auth_handler)
+        .auth_skip_paths({"/api/v1/public/*"});
+
+    simple_resource sr;
+    LT_ASSERT_EQ(true, ws.register_resource("api/v1/public/users/list", &sr));
+    ws.start(false);
+
+    curl_global_init(CURL_GLOBAL_ALL);
+    std::string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    long http_code = 0;  // NOLINT(runtime/int)
+
+    // Deep nested path should be skipped
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/api/v1/public/users/list");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 200);
+    LT_CHECK_EQ(s, "SUCCESS");
+    curl_easy_cleanup(curl);
+
+    ws.stop();
+LT_END_AUTO_TEST(auth_skip_paths_deep_nested)
+
+// Test POST method with centralized auth
+class post_resource : public http_resource {
+ public:
+     shared_ptr<http_response> render_POST(const http_request&) {
+         return std::make_shared<string_response>("POST_SUCCESS", 200, "text/plain");
+     }
+};
+
+LT_BEGIN_AUTO_TEST(authentication_suite, centralized_auth_post_method)
+    webserver ws = create_webserver(PORT)
+        .auth_handler(centralized_auth_handler);
+
+    post_resource pr;
+    LT_ASSERT_EQ(true, ws.register_resource("data", &pr));
+    ws.start(false);
+
+    curl_global_init(CURL_GLOBAL_ALL);
+    std::string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    long http_code = 0;  // NOLINT(runtime/int)
+
+    // POST without auth should fail
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/data");
+    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "test=data");
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 401);
+    curl_easy_cleanup(curl);
+
+    // POST with auth should succeed
+    curl = curl_easy_init();
+    s = "";
+    http_code = 0;
+    curl_easy_setopt(curl, CURLOPT_USERNAME, "admin");
+    curl_easy_setopt(curl, CURLOPT_PASSWORD, "secret");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/data");
+    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "test=data");
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 200);
+    LT_CHECK_EQ(s, "POST_SUCCESS");
+    curl_easy_cleanup(curl);
+
+    ws.stop();
+LT_END_AUTO_TEST(centralized_auth_post_method)
+
+// Test wrong credentials (different from no credentials)
+LT_BEGIN_AUTO_TEST(authentication_suite, centralized_auth_wrong_credentials)
+    webserver ws = create_webserver(PORT)
+        .auth_handler(centralized_auth_handler);
+
+    simple_resource sr;
+    LT_ASSERT_EQ(true, ws.register_resource("protected", &sr));
+    ws.start(false);
+
+    curl_global_init(CURL_GLOBAL_ALL);
+    std::string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    long http_code = 0;  // NOLINT(runtime/int)
+
+    // Wrong username
+    curl_easy_setopt(curl, CURLOPT_USERNAME, "wronguser");
+    curl_easy_setopt(curl, CURLOPT_PASSWORD, "secret");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/protected");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 401);
+    curl_easy_cleanup(curl);
+
+    // Wrong password
+    curl = curl_easy_init();
+    s = "";
+    http_code = 0;
+    curl_easy_setopt(curl, CURLOPT_USERNAME, "admin");
+    curl_easy_setopt(curl, CURLOPT_PASSWORD, "wrongpass");
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/protected");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 401);
+    curl_easy_cleanup(curl);
+
+    ws.stop();
+LT_END_AUTO_TEST(centralized_auth_wrong_credentials)
+
+// Test that 404 is returned for non-existent resources (auth doesn't interfere)
+LT_BEGIN_AUTO_TEST(authentication_suite, centralized_auth_not_found)
+    webserver ws = create_webserver(PORT)
+        .auth_handler(centralized_auth_handler);
+
+    simple_resource sr;
+    LT_ASSERT_EQ(true, ws.register_resource("exists", &sr));
+    ws.start(false);
+
+    curl_global_init(CURL_GLOBAL_ALL);
+    std::string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    long http_code = 0;  // NOLINT(runtime/int)
+
+    // Non-existent resource without auth - should get 401 (auth checked first)
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/nonexistent");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    // Note: Auth is only checked when resource is found, so 404 should be returned
+    LT_CHECK_EQ(http_code, 404);
+    curl_easy_cleanup(curl);
+
+    ws.stop();
+LT_END_AUTO_TEST(centralized_auth_not_found)
+
+// Test no auth handler (default behavior - no auth required)
+LT_BEGIN_AUTO_TEST(authentication_suite, no_auth_handler_default)
+    webserver ws = create_webserver(PORT);  // No auth_handler
+
+    simple_resource sr;
+    LT_ASSERT_EQ(true, ws.register_resource("open", &sr));
+    ws.start(false);
+
+    curl_global_init(CURL_GLOBAL_ALL);
+    std::string s;
+    CURL *curl = curl_easy_init();
+    CURLcode res;
+    long http_code = 0;  // NOLINT(runtime/int)
+
+    // Should succeed without any auth
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/open");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 200);
+    LT_CHECK_EQ(s, "SUCCESS");
+    curl_easy_cleanup(curl);
+
+    ws.stop();
+LT_END_AUTO_TEST(no_auth_handler_default)
+
+// Test multiple skip paths
+LT_BEGIN_AUTO_TEST(authentication_suite, auth_multiple_skip_paths)
+    webserver ws = create_webserver(PORT)
+        .auth_handler(centralized_auth_handler)
+        .auth_skip_paths({"/health", "/metrics", "/status", "/public/*"});
+
+    simple_resource sr;
+    LT_ASSERT_EQ(true, ws.register_resource("health", &sr));
+    LT_ASSERT_EQ(true, ws.register_resource("metrics", &sr));
+    LT_ASSERT_EQ(true, ws.register_resource("status", &sr));
+    LT_ASSERT_EQ(true, ws.register_resource("protected", &sr));
+    ws.start(false);
+
+    curl_global_init(CURL_GLOBAL_ALL);
+    CURL *curl;
+    CURLcode res;
+    long http_code = 0;  // NOLINT(runtime/int)
+    std::string s;
+
+    // All skip paths should work without auth
+    const char* skip_urls[] = {"/health", "/metrics", "/status"};
+    for (const char* url : skip_urls) {
+        curl = curl_easy_init();
+        s = "";
+        http_code = 0;
+        std::string full_url = std::string("localhost:" PORT_STRING) + url;
+        curl_easy_setopt(curl, CURLOPT_URL, full_url.c_str());
+        curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+        res = curl_easy_perform(curl);
+        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+        LT_ASSERT_EQ(res, 0);
+        LT_CHECK_EQ(http_code, 200);
+        curl_easy_cleanup(curl);
+    }
+
+    // Protected should still require auth
+    curl = curl_easy_init();
+    s = "";
+    http_code = 0;
+    curl_easy_setopt(curl, CURLOPT_URL, "localhost:" PORT_STRING "/protected");
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+    res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    LT_ASSERT_EQ(res, 0);
+    LT_CHECK_EQ(http_code, 401);
+    curl_easy_cleanup(curl);
+
+    ws.stop();
+LT_END_AUTO_TEST(auth_multiple_skip_paths)
+
 LT_BEGIN_AUTO_TEST_ENV()
     AUTORUN_TESTS()
 LT_END_AUTO_TEST_ENV()


### PR DESCRIPTION
## Summary

This PR adds a centralized authentication mechanism to libhttpserver that runs before any resource's render method is called. This addresses issue #102 where users had to copy authentication code into every `render_*` method.

**Features:**
- `auth_handler`: A callback that receives the `http_request` and can return `nullptr` to allow the request or an `http_response` to reject it
- `auth_skip_paths`: A vector of paths that bypass authentication (supports exact match and wildcard suffix like `/public/*`)

**Files changed:**
- `src/httpserver/create_webserver.hpp` - Added `auth_handler_ptr` typedef and builder methods
- `src/httpserver/webserver.hpp` - Added member variables and helper declaration
- `src/webserver.cpp` - Implemented auth check in request pipeline
- `test/integ/authentication.cpp` - Added 10 new test cases
- `examples/centralized_authentication.cpp` - New example file
- `README.md` - Documentation for the new feature

## Example Usage

```cpp
webserver ws = create_webserver(8080)
    .auth_handler([](const http_request& req) -> std::shared_ptr<http_response> {
        if (req.get_user() != "admin" || req.get_pass() != "secret") {
            return std::make_shared<basic_auth_fail_response>("Unauthorized", "MyRealm");
        }
        return nullptr;  // Allow request
    })
    .auth_skip_paths({"/health", "/public/*"});
```

## Test Plan

- [x] All existing tests pass (`make check`)
- [x] New tests added for:
  - Centralized auth rejection (401)
  - Centralized auth success (200)
  - Skip paths (exact match)
  - Skip paths (wildcard)
  - No partial prefix matching
  - Deep nested wildcard paths
  - POST method with auth
  - Wrong credentials
  - 404 for non-existent resources
  - Default behavior (no auth handler)
  - Multiple skip paths

Closes #102