### PR TITLE
Add ARM cross-compilation to GitHub Actions CI

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -571,19 +571,22 @@ jobs:
         tar -xzf libmicrohttpd-0.9.77.tar.gz
         mv libmicrohttpd-0.9.77 libmicrohttpd-0.9.77-${{ matrix.build-type }}
         cd libmicrohttpd-0.9.77-${{ matrix.build-type }}
+        mkdir -p ${{ github.workspace }}/arm-sysroot
         if [ "${{ matrix.build-type }}" = "arm32" ]; then
-          ./configure --host=arm-linux-gnueabihf --disable-examples --disable-doc
+          ./configure --host=arm-linux-gnueabihf --prefix=${{ github.workspace }}/arm-sysroot --disable-examples --disable-doc
         else
-          ./configure --host=aarch64-linux-gnu --disable-examples --disable-doc
+          ./configure --host=aarch64-linux-gnu --prefix=${{ github.workspace }}/arm-sysroot --disable-examples --disable-doc
         fi
         make
+        make install
       if: ${{ matrix.compiler-family == 'arm-cross' && steps.cache-libmicrohttpd-arm.outputs.cache-hit != 'true' }}
 
-    - name: Install cross-compiled libmicrohttpd
+    - name: Install cross-compiled libmicrohttpd from cache
       run: |
         cd libmicrohttpd-0.9.77-${{ matrix.build-type }}
-        sudo make install
-      if: ${{ matrix.compiler-family == 'arm-cross' }}
+        mkdir -p ${{ github.workspace }}/arm-sysroot
+        make install
+      if: ${{ matrix.compiler-family == 'arm-cross' && steps.cache-libmicrohttpd-arm.outputs.cache-hit == 'true' }}
 
     - name: Refresh links to shared libs
       run: sudo ldconfig ;
@@ -612,6 +615,9 @@ jobs:
         mkdir build ;
         cd build ;
         if [ "${{ matrix.compiler-family }}" = "arm-cross" ]; then
+          export CPPFLAGS="-I${{ github.workspace }}/arm-sysroot/include"
+          export LDFLAGS="-L${{ github.workspace }}/arm-sysroot/lib"
+          export PKG_CONFIG_PATH="${{ github.workspace }}/arm-sysroot/lib/pkgconfig"
           if [ "${{ matrix.build-type }}" = "arm32" ]; then
             ../configure --host=arm-linux-gnueabihf --disable-fastopen;
           else


### PR DESCRIPTION
## Summary
- Add ARM32 (ARMv7 hard-float) and ARM64 (AArch64) cross-compilation testing to GitHub Actions CI
- Validates that libhttpserver builds correctly for ARM targets
- Uses x86_64 runners with cross-compilation toolchains (build-only, no test execution)

## Changes
- Added two new matrix entries for ARM cross-compilation builds
- Added ARM toolchain installation step (`gcc-arm-linux-gnueabihf`, `gcc-aarch64-linux-gnu`)
- Added cached cross-compiled libmicrohttpd builds for ARM targets
- Updated configure step to pass `--host` flag for cross-compilation
- Skipped test execution and cppcheck for cross-compilation (binaries can't run on x86_64)

## Test plan
- [ ] Verify ARM32 job runs successfully and builds complete
- [ ] Verify ARM64 job runs successfully and builds complete
- [ ] Confirm tests are skipped (expected behavior for cross-compilation)
- [ ] Verify libmicrohttpd caching works correctly for ARM builds

Closes #131