### PR TITLE
Fix macOS CI: disable curl optional deps and bust stale cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: curl-7.75.0
-        key: macos-latest-CURL-pre-built-v2
+        key: macos-latest-CURL-pre-built-v3
 
     - name: Build curl (if not cached)
       if: steps.cache-curl.outputs.cache-hit != 'true'
@@ -211,7 +211,7 @@ jobs:
         curl https://libhttpserver.s3.amazonaws.com/travis_stuff/curl-7.75.0.tar.gz -o curl-7.75.0.tar.gz
         tar -xzf curl-7.75.0.tar.gz
         cd curl-7.75.0
-        ./configure --with-darwinssl --without-ssl
+        ./configure --with-darwinssl --without-ssl --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --without-zstd --without-librtmp --without-libpsl --disable-ldap --disable-ldaps
         make
 
     - name: Install curl

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -467,15 +467,15 @@ jobs:
       uses: actions/cache@v4
       with:
         path: curl-7.75.0
-        key: ${{ matrix.os }}-CURL-pre-built-v2
+        key: ${{ matrix.os }}-CURL-pre-built-v3
       if: ${{ matrix.os == 'macos-latest' }}
-    
+
     - name: Build CURL (for testing)
       run: |
         curl https://libhttpserver.s3.amazonaws.com/travis_stuff/curl-7.75.0.tar.gz -o curl-7.75.0.tar.gz ;
         tar -xzf curl-7.75.0.tar.gz ;
         cd curl-7.75.0 ;
-        ./configure --with-darwinssl --without-ssl ;
+        ./configure --with-darwinssl --without-ssl --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --without-zstd --without-librtmp --without-libpsl --disable-ldap --disable-ldaps ;
         make ;
       if: ${{ matrix.os == 'macos-latest' && steps.cache-CURL.outputs.cache-hit != 'true' }}
       


### PR DESCRIPTION
## Summary
- All five `macos-latest` jobs in [run 24945169734](https://github.com/etr/libhttpserver/actions/runs/24945169734) failed at `Install CURL (for testing on mac only)`. The cached `curl-7.75.0` tree (built when `macos-latest` had a different Homebrew layout) had `nghttp2` baked into the configured Makefile; on the current runner (15.7.4 ARM, `/opt/homebrew`) `sudo make install` triggers a recompile of `altsvc.lo` that fails with `'nghttp2/nghttp2.h' file not found`.
- Add `--without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --without-zstd --without-librtmp --without-libpsl --disable-ldap --disable-ldaps` to curl's `./configure` so the build is deterministic across runner images. Tests only need basic libcurl HTTP — none of these optional features are used.
- Bump cache key from `…-pre-built-v2` to `…-pre-built-v3` to discard the broken cache. Same change applied to `release.yml`.

## Test plan
- [ ] Verify Build workflow runs cleanly on all `macos-latest` matrix entries (gcc/clang × static/dynamic × debug/nodebug).
- [ ] Confirm `curl-7.75.0` rebuilds from scratch on first hit (cache miss expected with new key).
- [ ] Confirm subsequent runs hit the new cache and `sudo make install` succeeds without recompilation errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)